### PR TITLE
fix hostname error when using hypernode-importer on the vagrant node

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.hostmanager.ignore_private_ip = false
     config.hostmanager.include_offline = true
     config.vm.define 'hypernode' do |node|
-      node.vm.hostname = 'xxxxxx-dummy-magweb-xls.nodes.hypernode.io'
+      node.vm.hostname = 'xxxxxx-dummy-magweb-vgr.nodes.hypernode.io'
       node.vm.network :private_network, ip: '192.168.33.100'
       node.hostmanager.aliases = %w(example.hypernode.local hypernode-alias)
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.hostmanager.ignore_private_ip = false
     config.hostmanager.include_offline = true
     config.vm.define 'hypernode' do |node|
-      node.vm.hostname = 'xxxxxx-dummy-magweb-vgr.nodes.hypernode.io'
+      node.vm.hostname = 'xxxxxx-dummy-magweb-vgr.nodes.hypernode.local'
       node.vm.network :private_network, ip: '192.168.33.100'
       node.hostmanager.aliases = %w(example.hypernode.local hypernode-alias)
     end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,7 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.forward_agent = true
 
@@ -24,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.hostmanager.ignore_private_ip = false
     config.hostmanager.include_offline = true
     config.vm.define 'hypernode' do |node|
-      node.vm.hostname = 'hypernode.local'
+      node.vm.hostname = 'xxxxxx-dummy-magweb-xls.nodes.hypernode.io'
       node.vm.network :private_network, ip: '192.168.33.100'
       node.hostmanager.aliases = %w(example.hypernode.local hypernode-alias)
     end


### PR DESCRIPTION
Should fix: 

app@dummy:~$ hypernode-importer 
Traceback (most recent call last):
  File "/usr/bin/hypernode-importer", line 9, in <module>
    load_entry_point('kamikaze==20150304.160015', 'console_scripts', 'hypernode-importer')()
  File "/usr/lib/python2.7/dist-packages/kamikaze/migration/command.py", line 96, in main
    args = parse_arguments()
  File "/usr/lib/python2.7/dist-packages/kamikaze/migration/command.py", line 28, in parse_arguments
    hypernode_name = get_hypernode_name()
  File "/usr/lib/python2.7/dist-packages/kamikaze/migration/util.py", line 54, in get_hypernode_name
    raise ValueError("Could not determine full Hypernode name based on current hostname %s" % socket.gethostname())
ValueError: Could not determine full Hypernode name based on current hostname dummy
