### PR TITLE
Allow multiple hypernode vagrants at the same time

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "hypernode"
   config.vm.box_url = "http://vagrant.hypernode.com/catalog.json"
 
-  config.vm.network "forwarded_port", guest: 80, host: 8080
-  config.vm.network "forwarded_port", guest: 3306, host: 3307
+  config.vm.network "private_network", type: "dhcp"
+  config.vm.network "forwarded_port", guest: 80, host: 8080, auto_correct: true
+  config.vm.network "forwarded_port", guest: 3306, host: 3307, auto_correct: true
 
   config.vm.synced_folder "data/web/public/", "/data/web/public/", owner: "app", group: "app", create: true
   config.vm.synced_folder "data/web/nginx/", "/data/web/nginx/", owner: "app", group: "app", create: true
@@ -24,11 +25,50 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.hostmanager.manage_host = true
     config.hostmanager.ignore_private_ip = false
     config.hostmanager.include_offline = true
+
+    # Get the dynamic hostname from the running box so we know what to put in 
+    # /etc/hosts even though we don't specify a static private ip address
+    # For more information about why this is necessary see:
+    # https://github.com/smdahlen/vagrant-hostmanager/issues/86#issuecomment-183265949
+    config.hostmanager.ip_resolver = proc do |vm, resolving_vm|
+      if vm.communicate.ready?
+        result = ""
+        vm.communicate.execute("ifconfig eth1") do |type, data|
+          result << data if type == :stdout
+        end
+      end
+      (ip = /inet addr:(\d+\.\d+\.\d+\.\d+)/.match(result)) && ip[1]
+    end
+
     config.vm.define 'hypernode' do |node|
-      node.vm.hostname = 'xxxxxx-dummy-magweb-vgr.nodes.hypernode.local'
-      node.vm.network :private_network, ip: '192.168.33.100'
-      node.hostmanager.aliases = %w(hypernode.local example.hypernode.local hypernode-alias)
+      # Name the vagrant box after the directory the Vagrantfile is in. If the Vagrantfile
+      # is in a directory named 'hypernode-vagrant' assume the name of the parent directory.
+      # This is so there is a human readable difference between multiple test environments. 
+      working_directory = File.basename(Dir.getwd)
+      parent_directory = File.basename(File.expand_path("..", Dir.getwd))
+      directory_name = working_directory == "hypernode-vagrant" ? parent_directory : working_directory
+      hypernode_host = ENV['HYPERNODE_VAGRANT_NAME'] ? ENV['HYPERNODE_VAGRANT_NAME'] : directory_name
+      # remove special characters so we have a valid hostname
+      directory_alias = hypernode_host.gsub(/[^a-zA-Z0-9\-]/,"") + ".hypernode.local"
+
+      # The directory and parent directory don't have to be unique names. You
+      # could have this Vagrantfile in two subdirs each named 'mytestshop' and
+      # the directory aliases would be double. Because there can only be one
+      # Vagrantfile per directory, the path is always unique. We can create a
+      # unique alias (well at least semi-unique, there might be some
+      # collisions) with the hash of that path.
+      require 'digest/sha1'
+      hostname_hash = Digest::SHA1.hexdigest(Dir.pwd).slice(0..5) 
+      directory_hash_alias = hostname_hash + ".hypernode.local"
+
+      # set the machine hostname
+      node.vm.hostname = hostname_hash + "-" + hypernode_host + "-magweb-vgr.nodes.hypernode.local"
+
+      # Here you can define your own aliases for in the hosts file. 
+      # note: if you have more than one hypernode-vagrant checkout up and
+      # running, the static aliases will be defined for all of those boxes.
+      # This means that hypernode.local will belong to box you booted as last.
+      node.hostmanager.aliases = ["hypernode.local", "hypernode-alias", directory_alias, directory_hash_alias]
     end
   end
-
 end

--- a/data/web/public/index.php
+++ b/data/web/public/index.php
@@ -1,3 +1,8 @@
+<?php
+    $host_name = gethostname();
+    $host_name_parts = explode("-", $host_name);
+    $ready_name = count($host_name_parts) == 4 ? $host_name_parts[1] : $host_name;
+?>
 <!DOCTYPE html>
 <html>
 <head lang="en">
@@ -86,7 +91,7 @@
 <body>
 <header>
     <nav class="navbar" role="navigation">
-        <div id="vagrant"><div class="text-center"><h3>test environment</h3></div></div>
+        <div id="vagrant"><div class="text-center"><h3>test environment for <?php echo $ready_name; ?></h3></div></div>
         <div class="container">
             <div class="navbar-header">
                 <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">

--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -19,4 +19,6 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDSERHiEjdibIowB763wgGn4OCdko4b8WfqmgihgiIs
 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key
 EOF
 
+ln -s /var/lib/varnish/xxxxx-dummytag-vagrant.nodes.hypernode.io/ "/var/lib/varnish/`hostname`"
+
 rm -rf /etc/cron.d/hypernode-fpm-monitor


### PR DESCRIPTION
Previously there would be collision issues like ports, aliases and the hardcoded private IP.

- use dhcp for private networking
- get assigned IP address from the node with machine.communicate for [updating hosts](https://github.com/smdahlen/vagrant-hostmanager/issues/86)
- keep the hypernode.local alias.

If you only have one hypernode-vagrant running you can still access it
at hypernode.local for backwards compatibility with previous versions of this box.

- add alias for box name
- box name is directory if dir is not named hypernode-kamikaze

This is for when you use the Vagrantfile in the repository for a different project. If you put the Vagrantfile in a directory named 'mywebshop' the hypernode-vagrant will be available at ```http://mywebshop.hypernode.local```

- box name is parent if dir named hypernode-kamikaze

This is for when you create a complete hypernode-vagrant checkout in your project's directory. If you have a project directory named 'mywebshop' and you git clone this repository in that directory, the box will be named 'mywebshop' as well and is also accessible on ```http://mywebshop.hypernode.local```

- box name is specified environment variable

If you don't want to name the hypernode-vagrant box after the directory it is in, you can specify an env var to override the name.
```
HYPERNODE_VAGRANT_NAME="mywebshop" vagrant up
```
it will then be accessible at ```http://mywebshop.hypernode.local``` as well.

- add alias for hash of Vagrantfile path

Because you can run two hypernode-vagrant boxes with the same name at the same time (for example if you want to test two different branches for a shop) an alias is also added that is unique for the path of the Vagrantfile (because you won't be able to access both shops on ```http://webshop.hypernode.local```. The path hash alias is guaranteed to be unique because you can only have one Vagrantfile per directory.

This will create aliases like:
```
http://b033d-mywebshop-magweb-vgr.nodes.hypernode.local
http://eb7b8-mywebshop-magweb-vgr.nodes.hypernode.local
```

- link the compiled varnish config to the right directory for the box's
  hostname during provisioning

- the default index.php shows you the name of the box it's running on

looks like:
![screen1](https://cloud.githubusercontent.com/assets/1437341/13004456/db639a6a-d17b-11e5-9b7e-633fe0f7dff8.png)
