### PR TITLE
add default nginx files to /data/web/nginx

### DIFF
--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -22,3 +22,8 @@ EOF
 ln -s /var/lib/varnish/xxxxx-dummytag-vagrant.nodes.hypernode.io/ "/var/lib/varnish/`hostname`"
 
 rm -rf /etc/cron.d/hypernode-fpm-monitor
+
+# Copy default nginx configs to synced nginx directory if the files don't exist
+if [ -d /etc/hypernode/defaults/nginx/ ]; then
+	su app -c 'find /etc/hypernode/defaults/nginx -type f | xargs -I {} cp -n {} /data/web/nginx/'
+fi


### PR DESCRIPTION
if the files don't exist, copy them from /etc/hypernode/defaults/nginx if that dir exists (for backwards compatibility with versions < 2653)