### PR TITLE
note that virtualbox 5.0 is not yet supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ You can start developing on your own local Hypernode within 15 minutes.
 
 ## Starting the test environment
 
-1. Install [Virtualbox 4.3.18 or later](https://www.virtualbox.org/wiki/Downloads).
+1. Install [Virtualbox 4.3.18 or later but < 5.0](https://www.virtualbox.org/wiki/Downloads).
 2. Install [Vagrant 1.6.4 or later](http://www.vagrantup.com/downloads.html).
 3. Clone this [repository](https://github.com/ByteInternet/hypernode-vagrant.git) using Git or download the [zip file](https://github.com/ByteInternet/hypernode-vagrant/archive/master.zip) from Github.
 


### PR DESCRIPTION
```
   default: Guest Additions Version: 4.2.0
   default: VirtualBox Version: 5.0
==> default: Configuring and enabling network interfaces...
==> default: Mounting shared folders...
   default: /vagrant => /backup/hypernode-vagrant
Failed to mount folders in Linux guest. This is usually because
the "vboxsf" file system is not available. Please verify that
the guest additions are properly installed in the guest and
can work properly. The command attempted was:
 
mount -t vboxsf -o uid=`id -u vagrant`,gid=`getent group vagrant | cut -d: -f3` vagrant /vagrant
mount -t vboxsf -o uid=`id -u vagrant`,gid=`id -g vagrant` vagrant /vagrant
 
The error output from the last command was:
 
stdin: is not a tty
/sbin/mount.vboxsf: mounting failed with the error: No such device
```