### PR TITLE
Truncate any mails from building process

### DIFF
--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -3,6 +3,8 @@
 
 set -e
 
+truncate -s 0 /var/mail/app
+
 user="app"
 homedir=$(getent passwd $user | cut -d ':' -f6)
 sudo -u $user mkdir -p "$homedir/.ssh"


### PR DESCRIPTION
Truncate any mails from building process

Sometimes the system sends some mails during the building process which end up in the app user mail file because that's where all the sent mails are caught