### PR TITLE
skip synced folders loop if none defined

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -36,8 +36,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network "forwarded_port", guest: 80, host: 8080, auto_correct: true
   config.vm.network "forwarded_port", guest: 3306, host: 3307, auto_correct: true
 
-  settings['fs']['folders'].each do |name, folder|
-    config.vm.synced_folder folder['host'], folder['guest'], type: settings['fs']['type'], create: true
+  if !settings['fs']['folders'].nil?
+    settings['fs']['folders'].each do |name, folder|
+      config.vm.synced_folder folder['host'], folder['guest'], type: settings['fs']['type'], create: true
+    end
   end
 
   config.vm.provision "shell", path: "vagrant/provisioning/hypernode.sh"


### PR DESCRIPTION
to make the Vagrantfile backwards compatible with the old [example local.yml](https://github.com/ByteInternet/hypernode-vagrant/blob/934e523ec2e310d96eeea88d8b734de815757636/local.example.yml)


So this doesn't happen anymore after updating:
```
hypernode-vagrant/Vagrantfile:39:in `block in <top (required)>': undefined method `each' for nil:NilClass (NoMethodError)
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/config/v2/loader.rb:37:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/config/v2/loader.rb:37:in `load'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/config/loader.rb:103:in `block (2 levels) in load'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/config/loader.rb:97:in `each'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/config/loader.rb:97:in `block in load'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/config/loader.rb:94:in `each'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/config/loader.rb:94:in `load'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/vagrantfile.rb:28:in `initialize'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/environment.rb:689:in `new'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/environment.rb:689:in `vagrantfile'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/environment.rb:441:in `host'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/environment.rb:207:in `block in action_runner'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/runner.rb:33:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/action/runner.rb:33:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/environment.rb:428:in `hook'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/lib/vagrant/environment.rb:671:in `unload'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.7.4/bin/vagrant:177...
```