### PR TITLE
Fix synced folder permissions

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   if !settings['fs']['folders'].nil?
     settings['fs']['folders'].each do |name, folder|
-      config.vm.synced_folder folder['host'], folder['guest'], type: settings['fs']['type'], create: true
+      config.vm.synced_folder folder['host'], folder['guest'], type: settings['fs']['type'], create: true, owner: "app", group: "app"
     end
   end
 


### PR DESCRIPTION
owner and group got removed in https://github.com/ByteInternet/hypernode-vagrant/pull/48/files

fixes:
```
==> hypernode: Running provisioner: shell...
    hypernode: Running: /tmp/vagrant-shell20160321-8497-47qdiw.sh
==> hypernode: stdin: is not a tty
==> hypernode: cp: 
==> hypernode: cannot create regular file `/data/web/nginx/magmi.conf'
==> hypernode: : Permission denied
==> hypernode: cp: 
==> hypernode: cannot create regular file `/data/web/nginx/server.rewrites'
==> hypernode: : Permission denied
==> hypernode: cp: 
==> hypernode: cannot create regular file `/data/web/nginx/server.blacklist'
==> hypernode: : Permission denied
==> hypernode: cp: 
==> hypernode: cannot create regular file `/data/web/nginx/http.magerunmaps'
==> hypernode: : Permission denied
==> hypernode: cp: 
==> hypernode: cannot create regular file `/data/web/nginx/server.basicauth'
==> hypernode: : Permission denied
==> hypernode: cp: 
==> hypernode: cannot create regular file `/data/web/nginx/handler.conf'
==> hypernode: : Permission denied
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

@hongaar did you remove owner and group for a specific reason?