### PR TITLE
hostmanager resolves last eth iface (not first)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -86,7 +86,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.hostmanager.ip_resolver = proc do |vm, resolving_vm|
       if vm.communicate.ready?
         result = ""
-        vm.communicate.execute("ifconfig `find /sys/class/net -name 'eth*' -printf '%f\n' -quit`") do |type, data|
+        vm.communicate.execute("ifconfig `find /sys/class/net -name 'eth*' -printf '%f\n' | tail -n 1`") do |type, data|
           result << data if type == :stdout
         end
       end


### PR DESCRIPTION
On vbox eth1 and eth0 exist by default, on lxc only eth0 exists. We want
hostmanager to target eth1 because this is the private network.

So we get the same behavior as [before](https://github.com/ByteInternet/hypernode-vagrant/blob/a150f76ef314d3ac5a65a754f5339fbe579ae0ad/Vagrantfile#L85)