### PR TITLE
vagrant name filters away special characters

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -94,9 +94,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       working_directory = File.basename(Dir.getwd)
       parent_directory = File.basename(File.expand_path("..", Dir.getwd))
       directory_name = working_directory == "hypernode-vagrant" ? parent_directory : working_directory
-      hypernode_host = ENV['HYPERNODE_VAGRANT_NAME'] ? ENV['HYPERNODE_VAGRANT_NAME'] : directory_name
+      hypernode_vagrant_name = ENV['HYPERNODE_VAGRANT_NAME'] ? ENV['HYPERNODE_VAGRANT_NAME'] : directory_name
+      hypernode_host = hypernode_vagrant_name.gsub(/[^a-zA-Z0-9\-]/, "") 
+      hypernode_host = hypernode_host.empty? ? 'hypernode' : hypernode_host
+
       # remove special characters so we have a valid hostname
-      directory_alias = hypernode_host.gsub(/[^a-zA-Z0-9\-]/,"") + ".hypernode.local"
+      directory_alias = hypernode_host + ".hypernode.local"
 
       # The directory and parent directory don't have to be unique names. You
       # could have this Vagrantfile in two subdirs each named 'mytestshop' and


### PR DESCRIPTION
hostname based on parent directory name first filters away special characters

fixes:
```
banǡǡn & test/hypernode-vagrant$ vagrant destroy -f 
There are errors in the configuration of this machine. Please fix
the following errors and try again:

vm:
* The hostname set for the VM should only contain letters, numbers,
hyphens or dots. It cannot start with a hyphen or dot.
```