### PR TITLE
allow symlinks with vbox shared folders

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     override.vm.network "forwarded_port", guest: 80, host: 8080, auto_correct: true
     override.vm.network "forwarded_port", guest: 3306, host: 3307, auto_correct: true
     vbox.memory = 2048
+    vbox.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
   end
 
   config.vm.provider :lxc do |lxc, override|


### PR DESCRIPTION
fix symlinks in shared vbox dirs on windows

https://github.com/ByteInternet/hypernode-vagrant/issues/57
https://coderwall.com/p/b5mu2w/symlinks-in-shares-for-vagrant

@frits1980 @hongaar 