### PR TITLE
add magento2 setting to config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,16 @@ unless available_php_versions.include?(php_version)
   abort "Configure an available php version in local.yml: #{available_php_versions.join(', ')}. You specified: #{php_version}"
 end
 
+if settings['magento'].nil? or settings['magento']['version'].nil?
+  settings_magento_version = 2
+else
+  settings_magento_version = settings['magento']['version']
+end
+
+if settings['fs']['folders'].select{ |_, f| f['guest'].start_with?('/data/web/public') }.any? and settings['magento']['version'] == 2
+  abort "Can not configure a synced /data/web/public directory with Magento 2, this will be symlinked to /data/web/magento2!"
+end
+
 if !Vagrant.has_plugin?("vagrant-gatling-rsync") and settings['fs']['type'] == 'rsync'
   puts "Tip: run 'vagrant plugin install vagrant-gatling-rsync' to speed up \
 shared folder operations.\nYou can then sync with 'vagrant gatling-rsync-auto' \
@@ -70,7 +80,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  config.vm.provision "shell", path: "vagrant/provisioning/hypernode.sh"
+  config.vm.provision "shell", path: "vagrant/provisioning/hypernode.sh", args: "-m #{settings_magento_version}"
 
   config.vm.provider :virtualbox do |vbox, override|
     override.vm.network "private_network", type: "dhcp"

--- a/local.example.yml
+++ b/local.example.yml
@@ -1,9 +1,9 @@
 fs:
   type: virtualbox
   folders:
-    magento:
-      host: data/web/public/
-      guest: /data/web/public/
+    magento2:
+      host: data/web/magento2
+      guest: /data/web/magento2
     nginx:
       host: data/web/nginx/
       guest: /data/web/nginx/
@@ -13,3 +13,5 @@ hostmanager:
   extra-aliases:
     - my-custom-store-url1.local
     - my-custom-store-url2.local
+magento:
+  version: 2

--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -3,6 +3,13 @@
 
 set -e
 
+while getopts "m:" opt; do
+    case "$opt" in
+        m)
+            magento_version="$OPTARG" ;;
+    esac
+done
+
 truncate -s 0 /var/mail/app
 
 user="app"
@@ -29,8 +36,18 @@ rm -rf /etc/cron.d/hypernode-fpm-monitor
 
 # Copy default nginx configs to synced nginx directory if the files don't exist
 if [ -d /etc/hypernode/defaults/nginx/ ]; then
-	su app -c 'find /etc/hypernode/defaults/nginx -type f | xargs -I {} cp -n {} /data/web/nginx/'
+	find /etc/hypernode/defaults/nginx -type f | sudo -u $user xargs -I {} cp -n {} /data/web/nginx/
 fi
+
+if [ "$magento_version" == "2" ]; then
+	# Create magento 2 nginx flag file
+	sudo -u $user touch /data/web/nginx/magento2.flag
+	# Set correct symlink
+	rm -rf /data/web/public
+	sudo -u $user ln -fs /data/web/magento2/pub /data/web/public
+fi
+	
+touch "$homedir/.ssh/authorized_keys"
 
 echo "Your hypernode-vagrant is ready! Log in with:"
 echo "ssh app@hypernode.local -oStrictHostKeyChecking=no -A"


### PR DESCRIPTION
so that magento 2 settings can be activated during provisioning

>Activate Magento 2 mode

>Hypernode will activate all kinds of Magento 2 cleverness when you activate M2 mode. This happens when you put a file in /data/web/nginx/magento2.flag:
https://support.hypernode.com/knowledgebase/installing-magento-2-on-hypernode/

adapted from the Cream fork https://bitbucket.org/creaminternet/hypernode/commits/1e754b991703a8041d9171c6f036a3fc006c9c50. Thanks @dverkade and @kozie

- add magento version to the settings. default is magento 2
- use getopts to pass magento version to hypernode post provisioning script (not $1 because we want to add varnish enabled/disabled later from the config as well)
- create the magento2.flag and link the magento2 dir to /data/web/public


Some comments on the fork:

I don't think you need to manually trigger the nginx_config_reloader because the config dir is watched by an inotify-monitor so as soon as you touch the file the config is reloaded automatically
```
+	# Set correct nginx config
+	/usr/bin/nginx_config_reloader
```
see https://github.com/ByteInternet/nginx_config_reloader/blob/f97b2a373497ff6fd78a7a94bed7f6f5e7821019/nginx_config_reloader/__init__.py#L179


Rm'ing the public dir would make it easy to make the mistake of configuring the synced directory for Magento 1 but the magento_version setting for magento 2, resulting in the synced dir being deleted during Vagrant provisioning which might not be desirable.
```
+	rm -rf /data/web/public
```

To prevent that I've added a warning:
```
if settings['fs']['folders'].select{ |_, f| f['guest'].start_with?('/data/web/public') }.any? and settings['magento']['version'] == 2
  abort "Can not configure a synced /data/web/public directory with Magento 2, this will be symlinked to /data/web/magento2!"
end
```

I've put in a PR to disable sendfile for the Vagrant box during packaging so the following doesn't have to go in the hypernode.sh script anymore
```
+# Set Sendfile off
+sed -i 's/sendfile on/sendfile off/' /etc/nginx/nginx.conf
+
```

Will create a separate PR for enabling/disabling Varnish from the settings file
