### PR TITLE
varnish caching is configurable in the settings file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,6 +34,12 @@ else
   settings_magento_version = settings['magento']['version']
 end
 
+if settings['varnish'].nil? or settings['varnish']['enabled'].nil?
+  settings_varnish_enabled = false
+else
+  settings_varnish_enabled = settings['varnish']['enabled']
+end
+
 if settings['fs']['folders'].select{ |_, f| f['guest'].start_with?('/data/web/public') }.any? and settings['magento']['version'] == 2
   abort "Can not configure a synced /data/web/public directory with Magento 2, this will be symlinked to /data/web/magento2!"
 end
@@ -80,7 +86,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  config.vm.provision "shell", path: "vagrant/provisioning/hypernode.sh", args: "-m #{settings_magento_version}"
+  config.vm.provision "shell", path: "vagrant/provisioning/hypernode.sh", args: "-m #{settings_magento_version} -v #{settings_varnish_enabled}"
 
   config.vm.provider :virtualbox do |vbox, override|
     override.vm.network "private_network", type: "dhcp"

--- a/local.example.yml
+++ b/local.example.yml
@@ -15,3 +15,5 @@ hostmanager:
     - my-custom-store-url2.local
 magento:
   version: 2
+varnish:
+  enabled: false

--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -3,10 +3,12 @@
 
 set -e
 
-while getopts "m:" opt; do
+while getopts "m:v:" opt; do
     case "$opt" in
         m)
             magento_version="$OPTARG" ;;
+        v)
+            varnish_enabled="$OPTARG" ;;
     esac
 done
 
@@ -45,6 +47,17 @@ if [ "$magento_version" == "2" ]; then
 	# Set correct symlink
 	rm -rf /data/web/public
 	sudo -u $user ln -fs /data/web/magento2/pub /data/web/public
+fi
+
+# ensure varnish is running. in lxc vagrant boxes for some reason the varnish init script in /etc/init.d doesn't bring up the service on boot
+# todo: find out why varnish isn't always started on startup on lxc instances
+ps -ef | grep -v "grep" | grep varnishd -q || (service varnish start && sleep 1)
+
+if ! $varnish_enabled; then
+
+	su $user -c "echo -e 'vcl 4.0;\nbackend default {\n .host = \"127.0.0.1\";\n .port= \"8080\";\n}\nsub vcl_recv {\n return(pass);\n}' > /data/web/disabled_caching.vcl"
+	varnishadm vcl.load nocache /data/web/disabled_caching.vcl
+	varnishadm vcl.use nocache
 fi
 	
 touch "$homedir/.ssh/authorized_keys"


### PR DESCRIPTION
PR on [add-magento2-to-settings-file](https://github.com/ByteInternet/hypernode-vagrant/pull/72)

- disable varnish caching by default

this adds a varnish enabled item to the config file. when varnish
enabled is false the nocache vcl is loaded. we need a vcl that passes
all requests to disable varnish instead of stopping the service because
otherwise a completely different nginx config would need to be placed.

also a workaround to ensure varnish is running so that vcls can be loaded during provisioning. in lxc vagrant boxes for some reason the varnish init script in /etc/init.d doesn't bring up the service on startup
todo: find out why varnish isn't always started on startup on lxc instances (on my machine?). varnish in lxc vagrants does work in the integration envirnoment.