### PR TITLE
fix split before definition

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -138,9 +138,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       hypernode_vagrant_name = ENV['HYPERNODE_VAGRANT_NAME'] ? ENV['HYPERNODE_VAGRANT_NAME'] : directory_name
 
       # remove special characters so we have a valid hostname
-      hypernode_host = hypernode_host.split('-')[0]
       hypernode_host = hypernode_vagrant_name.gsub(/[^a-zA-Z0-9]/, "")
       hypernode_host = hypernode_host.empty? ? 'hypernode' : hypernode_host
+      hypernode_host = hypernode_host.split('-')[0]
 
       directory_alias = hypernode_host + ".hypernode.local"
 


### PR DESCRIPTION
```
Ricks-MacBook-Air:hypernode-vagrant vdloo$ vagrant status
/Users/vdloo/code/projects/hypernode-vagrant/Vagrantfile:141:in `block (2 levels) in <top (required)>': undefined method `split' for nil:NilClass (NoMethodError)
```