### PR TITLE
copy default web page as user

### DIFF
--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -61,8 +61,7 @@ ps -ef | grep -v "grep" | grep varnishd -q || (service varnish start && sleep 1)
 
 # if the webroot is empty, place our default index.php which shows the settings
 if ! find /data/web/public/ -mindepth 1 -name '*.php' -name '*.html' | read; then
-    cp /vagrant/vagrant/resources/index.php /data/web/public/index.php
-    chown app /data/web/public/index.php
+    sudo -u $user cp /vagrant/vagrant/resources/*.{php,js,css} /data/web/public/
 fi
 
 if ! $varnish_enabled; then


### PR DESCRIPTION
doing so as root can cause problems with nfs mounts because of the mask

fixes ownership issue for NFS mounts:
```
==> hypernode: Mounting shared folders...
    hypernode: /vagrant => /Users/vdloo/code/projects/hypernode-vagrant
==> hypernode: Updating /etc/hosts file on active guest machines...
==> hypernode: Updating /etc/hosts file on host machine (password may be required)...
==> hypernode: Running provisioner: shell...
    hypernode: Running: /var/folders/2p/cr2x4nxx4j9g_0hwvq078yr80000gn/T/vagrant-shell20160708-686-6xu8hy.sh
==> hypernode: stdin: is not a tty
==> hypernode: chown: changing ownership of `/data/web/public/index.php': Operation not permitted
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```