### PR TITLE
do not test with ruby 1 9 3 anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 rvm: 
-  - 1.9.3
   - 2.0
   - 2.1
   - 2.2


### PR DESCRIPTION
code coverage test dependency `json` 2.0 dropped support for Ruby 1.9.

```
Fetching: json-2.0.1.gem (100%)
ERROR:  Error installing simplecov:
	json requires Ruby version ~> 2.0.
ERROR:  Error installing coveralls:
	json requires Ruby version ~> 2.0.
```