### PR TITLE
add composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "byteinternet/hypernode-vagrant",
+    "description": "Easily configurable Magento Vagrant. Hypernode development environment.",
+    "type": "project",
+    "homepage": "https://github.com/byteinternet/hypernode-vagrant",
+    "license": "MIT",
+    "authors": [
+        {
+          "name": "Hypernode Team",
+          "homepage": "http://www.hypernode.com",
+          "role": "Developer"
+        }
+    ],
+    "require": {}
+}


### PR DESCRIPTION
so hypernode-vagrant can be a composer dependency

then if we add the repo to packagist (or the firegento repo) shops could put something like this in their composer.json:
```
    "require-dev": {
        "byteinternet/hypernode-vagrant": "dev-master"
    },
```

and run ```composer install``` without ```--no-dev```