### PR TITLE
vagrant 1.7.3 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can start developing on your own local Hypernode within 15 minutes.
 3. Clone this [repository](https://github.com/ByteInternet/hypernode-vagrant.git) using Git or download the [zip file](https://github.com/ByteInternet/hypernode-vagrant/archive/master.zip) from Github.
 
 ```
-    # check if vagrant version > 1.6.4 ?
+    # check if vagrant version > 1.7.3 ?
     vagrant --version
     cd hypernode-vagrant
     vagrant plugin install vagrant-hostmanager


### PR DESCRIPTION
need at least 1.7.3 for Virtualbox 5 boxfiles

```
# vagrant 1.7.2
Vagrant has detected that you have a version of VirtualBox installed
that is not supported. Please install one of the supported versions
listed below to use Vagrant:

4.0, 4.1, 4.2, 4.3
```