### PR TITLE
don't symlink /var/lib/varnish/hostname

### DIFF
--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -33,8 +33,10 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDSERHiEjdibIowB763wgGn4OCdko4b8WfqmgihgiIs
 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key
 EOF
 
-rm -f "/var/lib/varnish/`hostname`"
-ln -s /var/lib/varnish/xxxxx-dummytag-vagrant.nodes.hypernode.io/ "/var/lib/varnish/`hostname`"
+if [ "$HOSTNAME" != "xxxxx-dummytag-vagrant.nodes.hypernode.io" ]; then
+    rm -f "/var/lib/varnish/$HOSTNAME"
+    ln -s /var/lib/varnish/xxxxx-dummytag-vagrant.nodes.hypernode.io/ "/var/lib/varnish/`hostname`"
+fi
 
 rm -rf /etc/cron.d/hypernode-fpm-monitor
 


### PR DESCRIPTION
when the default dummy hostname is specified

```
==> hypernode: rm: 
==> hypernode: cannot remove `/var/lib/varnish/xxxxx-dummytag-vagrant.nodes.hypernode.io'
==> hypernode: : Is a directory
```