### PR TITLE
Update hypernode.sh

### DIFF
--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -86,4 +86,4 @@ touch "$homedir/.ssh/authorized_keys"
 
 echo "Your hypernode-vagrant is ready! Log in with:"
 echo "ssh app@hypernode.local -oStrictHostKeyChecking=no -A"
-echo "Or visit https://$(echo `hostname` | cut -d'-' -f2).hypernode.local in your browser"
+echo "Or visit http://$(echo `hostname` | cut -d'-' -f2).hypernode.local in your browser"


### PR DESCRIPTION
Now the notification is:
```
==> hypernode: Or visit https://git.hypernode.local in your browser
```

Which should be `http`, as there is no ssl available on the hypernode-vagrant box