### PR TITLE
copy empty webroot files as root then chown

### DIFF
--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -69,7 +69,8 @@ ps -ef | grep -v "grep" | grep varnishd -q || (service varnish start && sleep 1)
 
 # if the webroot is empty, place our default index.php which shows the settings
 if ! find /data/web/public/ -mindepth 1 -name '*.php' -name '*.html' | read; then
-    sudo -u $user cp /vagrant/vagrant/resources/*.{php,js,css} /data/web/public/
+    cp /vagrant/vagrant/resources/*.{php,js,css} /data/web/public/
+    chown -R $user:$user /data/web/public
 fi
 
 if ! $varnish_enabled; then


### PR DESCRIPTION
instead of copying them as the user. these files can be owned by 'vagrant' which makes the provisioning without a mounted webroot fail like:
```
+ sudo -u app cp /vagrant/vagrant/resources/index.php /vagrant/vagrant/resources/bootstrap.min.js /vagrant/vagrant/resources/jquery.min.js /vagrant/vagrant/resources/bootstrap.min.css /vagrant/vagrant/resources/opensans.css /vagrant/vagrant/resources/style.css /data/web/public/
cp: cannot stat `/vagrant/vagrant/resources/index.php': Permission denied
cp: cannot stat `/vagrant/vagrant/resources/bootstrap.min.js': Permission denied
cp: cannot stat `/vagrant/vagrant/resources/jquery.min.js': Permission denied
cp: cannot stat `/vagrant/vagrant/resources/bootstrap.min.css': Permission denied
cp: cannot stat `/vagrant/vagrant/resources/opensans.css': Permission denied
```