### PR TITLE
fix plugin autoinstall for vagrant 1.9.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ VAGRANTFILE_API_VERSION = "2"
 VAGRANT_HYPCONFIGMGMT_VERSION = "0.0.5"
 
 # if vagrant-hypconfigmgmt is not installed, install it and abort
-if !Vagrant.has_plugin?("vagrant-hypconfigmgmt", version = VAGRANT_HYPCONFIGMGMT_VERSION)
+if !Vagrant.has_plugin?("vagrant-hypconfigmgmt", version = VAGRANT_HYPCONFIGMGMT_VERSION) && !ARGV.include?("plugin")
   system("vagrant plugin install vagrant-hypconfigmgmt --plugin-version #{VAGRANT_HYPCONFIGMGMT_VERSION}")
   abort "Installed the vagrant-hypconfigmgmt plugin.\nFor the next configuration step, please again run: \"vagrant up\""
 end


### PR DESCRIPTION
Auto-installing using system after detecting has_plugin causes an
infinite loop with Vagrant 1.9.0 because the Vagrantfile is now loaded
during plugin install (which will cause it to install the plugin while
the plugin is being installed).

See: https://github.com/mitchellh/vagrant/issues/8055
And: https://github.com/ByteInternet/hypernode-vagrant/issues/118

Fixes:
```
hypernode-vagrant$ vagrant plugin uninstall vagrant-hypconfigmgmt
Exec error: fork/exec /opt/vagrant/embedded/bin/ruby: argument list too long
Installed the vagrant-hypconfigmgmt plugin.
For the next configuration step, please again run: "vagrant up"
Installed the vagrant-hypconfigmgmt plugin.
For the next configuration step, please again run: "vagrant up"
```

Todo: in the future replace this with Vagrant's officially-supported automated
plugin installation when they release that

> Sounds like we're getting an officially-supported method of requesting
> plugin installation from the Vagrantfile soon, though!
- https://github.com/WhoopInc/vagrant-s3auth/issues/32