### PR TITLE
Set LXC network bridge name to virbr0 for RedHat derivatives

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,6 +80,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.provider :lxc do |lxc, override|
       lxc.customize 'cgroup.memory.limit_in_bytes', '2048M'
+      if File.exists?('/etc/redhat-release')
+        lxc.customize 'network.link', 'virbr0'
+      end
     end
 
     if Vagrant.has_plugin?("vagrant-hostmanager")


### PR DESCRIPTION
This fixes #120. 

RedHat derivatives use a different bridge name(`virbr0`) than Debian derivatives(`lxcbr0`). 
The fix is quite simple, I just added an if statement if the file `/etc/redhat-release` exists and if so, set the lxc network bridge name to `virbr0`.

I tested this on CentOS and Fedora 24.