### PR TITLE
inline plugin to ensure varnish is running

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,7 @@ SETTINGS_FILE = "local.yml"
 # load the settingsfile or if it does not exist yet a hash where every attribute two levels deep is nil
 settings = YAML.load_file(SETTINGS_FILE) rescue Hash.new(Hash.new(nil))
 
+require_relative 'vagrant/plugins/inline/ensure-varnish.rb'
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # run hypernode-vagrant configuration wizard if needed during 'vagrant up'
   config.hypconfigmgmt.enabled = true  

--- a/vagrant/plugins/inline/ensure-varnish.rb
+++ b/vagrant/plugins/inline/ensure-varnish.rb
@@ -1,0 +1,36 @@
+require "vagrant"
+
+module VagrantPlugins
+  module VagrantInlinePlugin
+    class Command
+      def initialize(app, env)
+        @app = app
+        @env = env
+      end
+
+      def call(env)
+        env[:machine].communicate.sudo(
+          "ps -ef | grep -v \"grep\" | grep varnishd -q || (service varnish start && sleep 1)",
+          {:error_check => false}
+        ) do |type, data|
+          output = data.to_s.strip()
+          if output.include? "Starting HTTP accelerator varnishd"
+            env[:ui].info("Started Varnish")
+          end
+        end
+        @app.call(env)
+      end
+    end
+  end
+
+  class Plugin < Vagrant.plugin("2")
+    name "Ensure varnish is started as soon as the instance is started"
+
+    action_hook(:VagrantInlinePlugin) do |hook|
+      hook.after(
+        Vagrant::Action::Builtin::WaitForCommunicator, 
+        VagrantInlinePlugin::Command
+      )
+    end
+  end
+end

--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -41,6 +41,11 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDSERHiEjdibIowB763wgGn4OCdko4b8WfqmgihgiIs
 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key
 EOF
 
+# Restart varnish if the hostname changed
+if [ ! -d "/var/lib/varnish/$HOSTNAME" ]; then
+    service varnish restart && sleep 1
+fi
+
 rm -rf /etc/cron.d/hypernode-fpm-monitor
 
 # Copy default nginx configs to synced nginx directory if the files don't exist

--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -41,11 +41,6 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDSERHiEjdibIowB763wgGn4OCdko4b8WfqmgihgiIs
 ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key
 EOF
 
-# Restart varnish if the hostname changed
-if [ ! -d "/var/lib/varnish/$HOSTNAME" ]; then
-    service varnish restart
-fi
-
 rm -rf /etc/cron.d/hypernode-fpm-monitor
 
 # Copy default nginx configs to synced nginx directory if the files don't exist
@@ -64,10 +59,6 @@ if [ "$magento_version" == "2" ]; then
 else
     sudo -u $user rm -f /data/web/nginx/magento2.flag
 fi
-
-# ensure varnish is running. in lxc vagrant boxes for some reason the varnish init script in /etc/init.d doesn't bring up the service on boot
-# todo: find out why varnish isn't always started on startup on lxc instances
-ps -ef | grep -v "grep" | grep varnishd -q || (service varnish start && sleep 1)
 
 # if the webroot is empty, place our default index.php which shows the settings
 if ! find /data/web/public/ -mindepth 1 -name '*.php' -name '*.html' | read; then
@@ -132,8 +123,7 @@ if $xdebug_enabled; then
     echo "this article: https://support.hypernode.com/knowledgebase/install-xdebug-hypernode-vagrant/"
 fi
 
-if ! $varnish_enabled; then
-    su $user -c "echo -e 'vcl 4.0;\nbackend default {\n .host = \"127.0.0.1\";\n .port= \"8080\";\n}\nsub vcl_recv {\n return(pass);\n}' > /data/web/disabled_caching.vcl"
+if ! $varnish_enabled; then su $user -c "echo -e 'vcl 4.0;\nbackend default {\n .host = \"127.0.0.1\";\n .port= \"8080\";\n}\nsub vcl_recv {\n return(pass);\n}' > /data/web/disabled_caching.vcl"
     varnishadm vcl.list | grep -q nocache || varnishadm vcl.load nocache /data/web/disabled_caching.vcl
     varnishadm vcl.use nocache
 fi

--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -123,7 +123,8 @@ if $xdebug_enabled; then
     echo "this article: https://support.hypernode.com/knowledgebase/install-xdebug-hypernode-vagrant/"
 fi
 
-if ! $varnish_enabled; then su $user -c "echo -e 'vcl 4.0;\nbackend default {\n .host = \"127.0.0.1\";\n .port= \"8080\";\n}\nsub vcl_recv {\n return(pass);\n}' > /data/web/disabled_caching.vcl"
+if ! $varnish_enabled; then 
+    su $user -c "echo -e 'vcl 4.0;\nbackend default {\n .host = \"127.0.0.1\";\n .port= \"8080\";\n}\nsub vcl_recv {\n return(pass);\n}' > /data/web/disabled_caching.vcl"
     varnishadm vcl.list | grep -q nocache || varnishadm vcl.load nocache /data/web/disabled_caching.vcl
     varnishadm vcl.use nocache
 fi


### PR DESCRIPTION
the varnish sysvinit script does not bring up varnish on boot after halt
for some reason. this commit adds an inline plugin that will force start
varnish as soon as the vagrant is ready to communicate. this will make
varnish come back up even after a vagrant halt + vagrant up without
--provision.