### PR TITLE
Retrieve keys from ssh-agent and add to running vagrant node

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ You can use this config snippet for SSH to ease logging in and then just `ssh hy
         # because the host key will change over time
 ```
 
+A little helper script is provided that retrieves the ssh keys from your local ssh-agent and adds it to the ~app/.ssh/authorized_keys on the hypernode vagrant:
+```
+bin/sync-agent-keys
+```
+
 ### PHP version
 
 The default php version is 5.5. To boot a hypernode-vagrant box with php 7.0 edit the local.yml file or input 5.5 or 7.0 for when asked for the required php version when setting up your vagrant.
@@ -201,8 +206,8 @@ On Windows see ```C:\Windows\System32\drivers\etc\hosts```.
 
 ## Working with shared folders
 
-When you start the vagrant box by running `vagrant up`, vagrant will mount pre-defined directories on the guest onto the host machine (your local desktop). 
-This way you can work locally and make changes in your preferred IDE and view the results by visiting the vagrant box in your browser. 
+When you start the vagrant box by running `vagrant up`, vagrant will mount pre-defined directories on the guest onto the host machine (your local desktop).
+This way you can work locally and make changes in your preferred IDE and view the results by visiting the vagrant box in your browser.
 
 These shared directories are defined in local.yml, a configuration file created when you run `vagrant up` for the first time:
 
@@ -222,7 +227,7 @@ These shared directories are defined in local.yml, a configuration file created 
           guest: /data/web/magento2
 ```
 
-All mountpoints defined in `folders` that have their own `host` and `guest` paths are mounted when setting up. 
+All mountpoints defined in `folders` that have their own `host` and `guest` paths are mounted when setting up.
 If you want to add your own mountpoints, you can add your own section:
 
 ```

--- a/bin/sync-agent-keys
+++ b/bin/sync-agent-keys
@@ -1,0 +1,31 @@
+#!/bin/bash
+TMPFILE="$( mktemp )"
+
+## Test if there are keys loaded in the SSH agent
+if (ssh-add -l | grep -q "The SSH agent has no identities" ) ; then
+    echo "Please add some keys to your ssh agent first!"
+    exit 1
+fi
+
+## Get all keys from SSH agent
+echo "Getting all keys from SSH agent"
+for KEY in $( ssh-add -l  | awk '{print $(NF-1) }' ); do
+    PUBKEY="${KEY}.pub"
+    if [ ! -f "$PUBKEY" ] ; then
+        echo "Public key for $KEY not found! Skipping..."
+        continue
+    fi
+    cat $PUBKEY >> $TMPFILE && echo >> $TMPFILE
+done
+
+## Echo keys to ~app/.ssh/authorized_keys
+echo "Putting public keys on vagrant node"
+cat $TMPFILE | vagrant ssh -- "cat - > /tmp/key ; sudo mkdir -p /data/web/.ssh ; sudo mv /tmp/key /data/web/.ssh/authorized_keys ; sudo chmod 600 /data/web/.ssh/authorized_keys ; sudo chown app:app /data/web/.ssh/authorized_keys"
+
+## Validate output and retrieve ip
+if [ "$?" != 0 ]; then
+   echo "Something went wrong placing your public key on your hypernode vagrant"
+else
+   IP="$( vagrant ssh -- "ifconfig eth1 | grep inet"   | cut -d: -f2 | awk '{print $1}')"
+   echo "You can now log in with ssh as user app@$IP"
+fi


### PR DESCRIPTION
This simple bash script retrieves the ssh keys from your local ssh-agent and adds it's public keys to the hypernode-vagrant