### PR TITLE
do not buffer hypernode-vagrant-runner stdout

### DIFF
--- a/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/runner/remote_command.py
+++ b/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/runner/remote_command.py
@@ -1,11 +1,12 @@
 from logging import getLogger
-from subprocess import CalledProcessError
+from subprocess import CalledProcessError, check_call
 
 from os import system
+from sys import stdout
 
 from hypernode_vagrant_runner.settings import HYPERNODE_VAGRANT_DEFAULT_USER, \
     UPLOAD_PATH
-from hypernode_vagrant_runner.utils import write_output_to_stdout, run_local_command
+from hypernode_vagrant_runner.utils import write_output_to_stdout
 
 try:
     # Import quote from shlex in case of python 3
@@ -55,7 +56,7 @@ def run_command_in_vagrant(command_to_run, vagrant_info,
         vagrant_info, ssh_user=ssh_user, command_to_run=command_to_run
     )
     try:
-        run_local_command(ssh_wrapper_command, shell=True)
+        check_call(ssh_wrapper_command, shell=True, stdout=stdout, bufsize=1)
     except CalledProcessError as e:
         log.info("Running command in Vagrant exited nonzero")
         write_output_to_stdout(e.output)

--- a/tools/hypernode-vagrant-runner/tests/unit/hypernode_vagrant_runner/runner/remote_command/test_run_command_in_vagrant.py
+++ b/tools/hypernode-vagrant-runner/tests/unit/hypernode_vagrant_runner/runner/remote_command/test_run_command_in_vagrant.py
@@ -1,3 +1,5 @@
+from sys import stdout
+
 from mock import Mock
 from subprocess import CalledProcessError
 
@@ -16,8 +18,8 @@ class TestRunCommandInVagrant(TestCase):
             'Port': '2222',
             'IdentityFile': '/tmp/tmpZrTKrM/.vagrant/machines/hypernode/virtualbox/private_key'
         }
-        self.run_local_command = self.set_up_patch(
-            'hypernode_vagrant_runner.runner.remote_command.run_local_command'
+        self.check_call = self.set_up_patch(
+            'hypernode_vagrant_runner.runner.remote_command.check_call'
         )
         self.write_output_to_stdout = self.set_up_patch(
             'hypernode_vagrant_runner.runner.remote_command.write_output_to_stdout'
@@ -45,8 +47,9 @@ class TestRunCommandInVagrant(TestCase):
     def test_run_command_in_vagrant_runs_local_command(self):
         run_command_in_vagrant('bash runtests.sh', self.vagrant_ssh_config)
 
-        self.run_local_command.assert_called_once_with(
-            self.wrap_ssh_call.return_value, shell=True
+        self.check_call.assert_called_once_with(
+            self.wrap_ssh_call.return_value, shell=True,
+            stdout=stdout, bufsize=1
         )
 
     def test_run_command_does_not_write_error_output_to_stdout_if_no_error(self):
@@ -57,7 +60,7 @@ class TestRunCommandInVagrant(TestCase):
     def test_run_command_writes_error_output_to_stdout_if_error(self):
         self.output = Mock()
 
-        self.run_local_command.side_effect = CalledProcessError(
+        self.check_call.side_effect = CalledProcessError(
             1, 'bash runtests.sh', output=self.output
         )
 


### PR DESCRIPTION
write the output of the command that runs in the machine to stdout directly