### PR TITLE
do not write CalledProcessErrors to stdout

### DIFF
--- a/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/runner/remote_command.py
+++ b/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/runner/remote_command.py
@@ -6,7 +6,6 @@ from sys import stdout
 
 from hypernode_vagrant_runner.settings import HYPERNODE_VAGRANT_DEFAULT_USER, \
     UPLOAD_PATH
-from hypernode_vagrant_runner.utils import write_output_to_stdout
 
 try:
     # Import quote from shlex in case of python 3
@@ -57,9 +56,8 @@ def run_command_in_vagrant(command_to_run, vagrant_info,
     )
     try:
         check_call(ssh_wrapper_command, shell=True, stdout=stdout, bufsize=1)
-    except CalledProcessError as e:
+    except CalledProcessError:
         log.info("Running command in Vagrant exited nonzero")
-        write_output_to_stdout(e.output)
 
 
 def get_remote_shell(vagrant_info, ssh_user=HYPERNODE_VAGRANT_DEFAULT_USER):

--- a/tools/hypernode-vagrant-runner/tests/unit/hypernode_vagrant_runner/runner/remote_command/test_run_command_in_vagrant.py
+++ b/tools/hypernode-vagrant-runner/tests/unit/hypernode_vagrant_runner/runner/remote_command/test_run_command_in_vagrant.py
@@ -1,8 +1,5 @@
 from sys import stdout
 
-from mock import Mock
-from subprocess import CalledProcessError
-
 from hypernode_vagrant_runner.runner import run_command_in_vagrant
 from hypernode_vagrant_runner.settings import HYPERNODE_VAGRANT_DEFAULT_USER
 from tests.testcase import TestCase
@@ -20,9 +17,6 @@ class TestRunCommandInVagrant(TestCase):
         }
         self.check_call = self.set_up_patch(
             'hypernode_vagrant_runner.runner.remote_command.check_call'
-        )
-        self.write_output_to_stdout = self.set_up_patch(
-            'hypernode_vagrant_runner.runner.remote_command.write_output_to_stdout'
         )
 
     def test_run_command_in_vagrant_wraps_ssh_call(self):
@@ -51,19 +45,3 @@ class TestRunCommandInVagrant(TestCase):
             self.wrap_ssh_call.return_value, shell=True,
             stdout=stdout, bufsize=1
         )
-
-    def test_run_command_does_not_write_error_output_to_stdout_if_no_error(self):
-        run_command_in_vagrant('bash runtests.sh', self.vagrant_ssh_config)
-
-        self.assertFalse(self.write_output_to_stdout.called)
-
-    def test_run_command_writes_error_output_to_stdout_if_error(self):
-        self.output = Mock()
-
-        self.check_call.side_effect = CalledProcessError(
-            1, 'bash runtests.sh', output=self.output
-        )
-
-        run_command_in_vagrant('bash runtests.sh', self.vagrant_ssh_config)
-
-        self.write_output_to_stdout.assert_called_once_with(self.output)


### PR DESCRIPTION
the run_command_in_vagrant function now writes to stdout