### PR TITLE
add empty xenial image

### DIFF
--- a/vagrant/plugins/vagrant-hypconfigmgmt/lib/vagrant-hypconfigmgmt/command.rb
+++ b/vagrant/plugins/vagrant-hypconfigmgmt/lib/vagrant-hypconfigmgmt/command.rb
@@ -269,15 +269,20 @@ HEREDOC
 
     def ensure_vagrant_box_type_configured(env)
       settings = retrieve_settings()
-      case settings['php']['version']
-        when 5.5
-          env[:ui].info("Will use PHP 5.5. If you want PHP 7 instead change the php version in local.yml.")
-          settings['vagrant']['box'] = 'hypernode_php5'
-          settings['vagrant']['box_url'] = 'http://vagrant.hypernode.com/customer/php5/catalog.json'
-        when 7.0
-          env[:ui].info("Will use PHP 7. If you want PHP 5.5 instead change the php version in local.yml.")
-          settings['vagrant']['box'] = 'hypernode_php7'
-          settings['vagrant']['box_url'] = 'http://vagrant.hypernode.com/customer/php7/catalog.json'
+      if settings['ubuntu_version'] == 'xenial'
+        settings['vagrant']['box'] = 'hypernode'
+        settings['vagrant']['box_url'] = 'http://vagrant.hypernode.com/customer/xenial/catalog.json'
+      else
+        case settings['php']['version']
+          when 5.5
+            env[:ui].info("Will use PHP 5.5. If you want PHP 7 instead change the php version in local.yml.")
+            settings['vagrant']['box'] = 'hypernode_php5'
+            settings['vagrant']['box_url'] = 'http://vagrant.hypernode.com/customer/php5/catalog.json'
+          when 7.0
+            env[:ui].info("Will use PHP 7. If you want PHP 5.5 instead change the php version in local.yml.")
+            settings['vagrant']['box'] = 'hypernode_php7'
+            settings['vagrant']['box_url'] = 'http://vagrant.hypernode.com/customer/php7/catalog.json'
+        end
       end
       update_settings(settings)
     end

--- a/vagrant/plugins/vagrant-hypconfigmgmt/spec/unit/command/ensure_vagrant_box_type_configured_spec.rb
+++ b/vagrant/plugins/vagrant-hypconfigmgmt/spec/unit/command/ensure_vagrant_box_type_configured_spec.rb
@@ -36,7 +36,48 @@ describe VagrantHypconfigmgmt::Command do
 	  }, 
 	  "vagrant" => { 
 	    "box" => "hypernode_php7", 
-	    "box_url" => "http://vagrant.hypernode.com/customer/php7/catalog.json" } 
+	    "box_url" => "http://vagrant.hypernode.com/customer/php7/catalog.json" 
+	  } 
+	}
+	# check if settings are retrieved from disk and pretend they return a configuration for php 7.0
+        expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the settings that are written back to disk contain the right box (name) and box_url
+        expect(subject).to receive(:update_settings).once.with(expected_settings)
+      end
+    end
+
+    context "when php 7.0 is configured and precise ubuntu version specified" do
+      let(:retrieved_settings) { { "php" => { "version" => 7.0 }, "vagrant" => Hash.new, "ubuntu_version" => "precise" } }
+      it "sets the box name and box url to the right values for PHP 7.0" do
+	expected_settings = { 
+          "ubuntu_version" => "precise",
+          "php" => { 
+	    "version" => 7.0
+	  }, 
+	  "vagrant" => { 
+	    "box" => "hypernode_php7", 
+	    "box_url" => "http://vagrant.hypernode.com/customer/php7/catalog.json" 
+	  } 
+	}
+	# check if settings are retrieved from disk and pretend they return a configuration for php 7.0
+        expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the settings that are written back to disk contain the right box (name) and box_url
+        expect(subject).to receive(:update_settings).once.with(expected_settings)
+      end
+    end
+
+    context "when php 7.0 is configured and xenial ubuntu version specified" do
+      let(:retrieved_settings) { { "php" => { "version" => 7.0 }, "vagrant" => Hash.new, "ubuntu_version" => "xenial" } }
+      it "sets the box name and box url to the right values for PHP 7.0" do
+	expected_settings = { 
+          "ubuntu_version" => "xenial",
+          "php" => { 
+	    "version" => 7.0
+	  }, 
+	  "vagrant" => { 
+	    "box" => "hypernode", 
+	    "box_url" => "http://vagrant.hypernode.com/customer/xenial/catalog.json" 
+	  } 
 	}
 	# check if settings are retrieved from disk and pretend they return a configuration for php 7.0
         expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
@@ -54,7 +95,48 @@ describe VagrantHypconfigmgmt::Command do
 	  }, 
 	  "vagrant" => { 
 	    "box" => "hypernode_php5", 
-	    "box_url" => "http://vagrant.hypernode.com/customer/php5/catalog.json" } 
+	    "box_url" => "http://vagrant.hypernode.com/customer/php5/catalog.json" 
+	  } 
+	}
+	# check if settings are retrieved from disk and pretend they return a configuration for php 5.5
+        expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the settings that are written back to disk contain the right box (name) and box_url
+        expect(subject).to receive(:update_settings).once.with(expected_settings)
+      end
+    end
+
+    context "when php 5.5 is configured and precise ubuntu version specified" do
+      let(:retrieved_settings) { { "php" => { "version" => 5.5 }, "vagrant" => Hash.new, "ubuntu_version" => "precise" } }
+      it "sets the box name and box url to the right values for PHP 5.5" do
+	expected_settings = { 
+          "ubuntu_version" => "precise",
+          "php" => { 
+	    "version" => 5.5 
+	  }, 
+	  "vagrant" => { 
+	    "box" => "hypernode_php5", 
+	    "box_url" => "http://vagrant.hypernode.com/customer/php5/catalog.json" 
+	  } 
+	}
+	# check if settings are retrieved from disk and pretend they return a configuration for php 5.5
+        expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the settings that are written back to disk contain the right box (name) and box_url
+        expect(subject).to receive(:update_settings).once.with(expected_settings)
+      end
+    end
+
+    context "when php 5.5 is configured and xenial ubuntu version specified" do
+      let(:retrieved_settings) { { "php" => { "version" => 5.5 }, "vagrant" => Hash.new, "ubuntu_version" => "xenial" } }
+      it "sets the box name and box url to the right values for PHP 5.5" do
+	expected_settings = { 
+          "ubuntu_version" => "xenial",
+          "php" => { 
+	    "version" => 5.5 
+	  }, 
+	  "vagrant" => { 
+	    "box" => "hypernode", 
+	    "box_url" => "http://vagrant.hypernode.com/customer/xenial/catalog.json" 
+	  } 
 	}
 	# check if settings are retrieved from disk and pretend they return a configuration for php 5.5
         expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
@@ -65,7 +147,17 @@ describe VagrantHypconfigmgmt::Command do
 
     context "when an unknown php version is configured" do
       let(:retrieved_settings) { { "php" => { "version" => 1.0 }, "vagrant" => Hash.new } }
-      it "do not set the box name and box url" do
+      it "does not set the box name and box url" do
+	# check if settings are retrieved from disk and pretend they return an invalid php version
+        expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the settings we write back to disk have an unaltered box (name) and box_url
+        expect(subject).to receive(:update_settings).once.with(retrieved_settings)
+      end
+    end
+
+    context "when an unknown php version is configured and xenial ubuntu vreesion specified" do
+      let(:retrieved_settings) { { "php" => { "version" => 1.0 }, "vagrant" => Hash.new, "ubuntu_version" => "xenial" } }
+      it "does not set the box name and box url" do
 	# check if settings are retrieved from disk and pretend they return an invalid php version
         expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
 	# check if the settings we write back to disk have an unaltered box (name) and box_url


### PR DESCRIPTION
currently this is an empty Ubuntu 16 image and no Hypernode yet, by
adding this as an option to the settings already we can use the
perhipheral tooling around hypernode-vagrant to run automated tests
during development.