### PR TITLE
do not install vagrant-hypconfigmgt on status

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ VAGRANTFILE_API_VERSION = "2"
 VAGRANT_HYPCONFIGMGMT_VERSION = "0.0.7"
 
 # if vagrant-hypconfigmgmt is not installed, install it and abort
-if !Vagrant.has_plugin?("vagrant-hypconfigmgmt", version = VAGRANT_HYPCONFIGMGMT_VERSION) && !ARGV.include?("plugin")
+if !Vagrant.has_plugin?("vagrant-hypconfigmgmt", version = VAGRANT_HYPCONFIGMGMT_VERSION) && !ARGV.include?("plugin") && !ARGV.include("status")
   system("vagrant plugin install vagrant-hypconfigmgmt --plugin-version #{VAGRANT_HYPCONFIGMGMT_VERSION}")
   abort "Installed the vagrant-hypconfigmgmt plugin.\nFor the next configuration step, please again run: \"vagrant up\""
 end


### PR DESCRIPTION
prevents things like this from happening:
```
vagrant global-status --prune
fatal: Not a git repository (or any of the parent directories): .git
Installing the 'vagrant-hypconfigmgmt --version '0.0.5'' plugin. This can take a few minutes...
```

see https://github.com/ByteInternet/hypernode-vagrant/pull/119