### PR TITLE
xenial is option in vagrant up prompt

### DIFF
--- a/vagrant/plugins/vagrant-hypconfigmgmt/lib/vagrant-hypconfigmgmt/command.rb
+++ b/vagrant/plugins/vagrant-hypconfigmgmt/lib/vagrant-hypconfigmgmt/command.rb
@@ -36,6 +36,9 @@ AVAILABLE_FS_TYPES = ['nfs', 'nfs_guest', 'virtualbox', 'rsync']
 # Perhaps we should consider using a different default on different platforms.
 DEFAULT_FS_TYPE = 'virtualbox'
 
+AVAILABLE_UBUNTU_VERSIONS = ['xenial', 'precise']
+DEFAULT_UBUNTU_VERSION = 'xenial'
+
 
 module VagrantHypconfigmgmt
   class Command
@@ -187,6 +190,20 @@ module VagrantHypconfigmgmt
     end
 
 
+    def get_ubuntu_version(env)
+      ask_message = "What Ubuntu version do you want to use? Options: xenial, precise (deprecated) [default #{DEFAULT_UBUNTU_VERSION}]: "
+      ubuntu_version = get_setting(env, AVAILABLE_UBUNTU_VERSIONS, DEFAULT_UBUNTU_VERSION, ask_message)
+      case ubuntu_version
+        when "xenial"
+          message = ("Will use the Xenial version. This is the default.")
+        when "precise"
+          message = ("Will use the Precise version (will soon be deprecated)")
+      end 
+      env[:ui].info(message)
+      return ubuntu_version
+    end
+
+
     # Make sure we don't link /data/web/public on Magento 2 Vagrants
     # because that dir will be a symlink to /data/web/magento2/pub and 
     # we mount that. On Magento 1 Vagrants we need to make sure we don't
@@ -268,9 +285,9 @@ HEREDOC
       end
     end
 
-
     def ensure_vagrant_box_type_configured(env)
       settings = retrieve_settings()
+      settings['ubuntu_version'] ||= get_ubuntu_version(env)
       if settings['ubuntu_version'] == 'xenial'
         settings['vagrant']['box'] = 'hypernode_xenial'
         settings['vagrant']['box_url'] = 'http://vagrant.hypernode.com/customer/xenial/catalog.json'
@@ -288,7 +305,6 @@ HEREDOC
       end
       update_settings(settings)
     end
-
 
     def ensure_default_domain_configured(env)
       settings = retrieve_settings()

--- a/vagrant/plugins/vagrant-hypconfigmgmt/spec/unit/command/ensure_vagrant_box_type_configured_spec.rb
+++ b/vagrant/plugins/vagrant-hypconfigmgmt/spec/unit/command/ensure_vagrant_box_type_configured_spec.rb
@@ -27,10 +27,11 @@ describe VagrantHypconfigmgmt::Command do
   # the method that we are going to test
   describe "#ensure_vagrant_box_type_configured" do
 
-    context "when php 7.0 is configured" do
+    context "when php 7.0 is configured but no ubuntu version specified" do
       let(:retrieved_settings) { { "php" => { "version" => 7.0 }, "vagrant" => Hash.new } }
       it "sets the box name and box url to the right values for PHP 7.0" do
 	expected_settings = { 
+          "ubuntu_version" => "precise",
           "php" => { 
 	    "version" => 7.0
 	  }, 
@@ -41,6 +42,8 @@ describe VagrantHypconfigmgmt::Command do
 	}
 	# check if settings are retrieved from disk and pretend they return a configuration for php 7.0
         expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the ubuntu version is gotten and pretend it returns precise
+	expect(subject).to receive(:get_ubuntu_version).once.with(env).and_return('precise')
 	# check if the settings that are written back to disk contain the right box (name) and box_url
         expect(subject).to receive(:update_settings).once.with(expected_settings)
       end
@@ -61,6 +64,8 @@ describe VagrantHypconfigmgmt::Command do
 	}
 	# check if settings are retrieved from disk and pretend they return a configuration for php 7.0
         expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the ubuntu version is not gotten because we already have it specified in the settings
+	expect(subject).to receive(:get_ubuntu_version).never
 	# check if the settings that are written back to disk contain the right box (name) and box_url
         expect(subject).to receive(:update_settings).once.with(expected_settings)
       end
@@ -81,15 +86,18 @@ describe VagrantHypconfigmgmt::Command do
 	}
 	# check if settings are retrieved from disk and pretend they return a configuration for php 7.0
         expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the ubuntu version is not gotten because we already have it specified in the settings
+	expect(subject).to receive(:get_ubuntu_version).never
 	# check if the settings that are written back to disk contain the right box (name) and box_url
         expect(subject).to receive(:update_settings).once.with(expected_settings)
       end
     end
 
-    context "when php 5.5 is configured" do
+    context "when php 5.5 is configured but no ubuntu version specified" do
       let(:retrieved_settings) { { "php" => { "version" => 5.5 }, "vagrant" => Hash.new } }
       it "sets the box name and box url to the right values for PHP 5.5" do
 	expected_settings = { 
+          "ubuntu_version" => "precise",
           "php" => { 
 	    "version" => 5.5 
 	  }, 
@@ -100,6 +108,8 @@ describe VagrantHypconfigmgmt::Command do
 	}
 	# check if settings are retrieved from disk and pretend they return a configuration for php 5.5
         expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the ubuntu version is gotten and pretend it returns precise
+	expect(subject).to receive(:get_ubuntu_version).once.with(env).and_return('precise')
 	# check if the settings that are written back to disk contain the right box (name) and box_url
         expect(subject).to receive(:update_settings).once.with(expected_settings)
       end
@@ -120,6 +130,8 @@ describe VagrantHypconfigmgmt::Command do
 	}
 	# check if settings are retrieved from disk and pretend they return a configuration for php 5.5
         expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the ubuntu version is not gotten because we already have it specified in the settings
+	expect(subject).to receive(:get_ubuntu_version).never
 	# check if the settings that are written back to disk contain the right box (name) and box_url
         expect(subject).to receive(:update_settings).once.with(expected_settings)
       end
@@ -140,6 +152,8 @@ describe VagrantHypconfigmgmt::Command do
 	}
 	# check if settings are retrieved from disk and pretend they return a configuration for php 5.5
         expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the ubuntu version is not gotten because we already have it specified in the settings
+	expect(subject).to receive(:get_ubuntu_version).never
 	# check if the settings that are written back to disk contain the right box (name) and box_url
         expect(subject).to receive(:update_settings).once.with(expected_settings)
       end
@@ -148,18 +162,29 @@ describe VagrantHypconfigmgmt::Command do
     context "when an unknown php version is configured" do
       let(:retrieved_settings) { { "php" => { "version" => 1.0 }, "vagrant" => Hash.new } }
       it "does not set the box name and box url" do
+	expected_settings = { 
+          "ubuntu_version" => "precise",
+          "php" => { 
+	    "version" => 1.0
+	  }, 
+	  "vagrant" => Hash.new
+	}
 	# check if settings are retrieved from disk and pretend they return an invalid php version
         expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the ubuntu version is gotten and pretend it returns precise
+	expect(subject).to receive(:get_ubuntu_version).once.with(env).and_return('precise')
 	# check if the settings we write back to disk have an unaltered box (name) and box_url
-        expect(subject).to receive(:update_settings).once.with(retrieved_settings)
+        expect(subject).to receive(:update_settings).once.with(expected_settings)
       end
     end
 
-    context "when an unknown php version is configured and xenial ubuntu vreesion specified" do
+    context "when an unknown php version is configured and xenial ubuntu version specified" do
       let(:retrieved_settings) { { "php" => { "version" => 1.0 }, "vagrant" => Hash.new, "ubuntu_version" => "xenial" } }
       it "does not set the box name and box url" do
 	# check if settings are retrieved from disk and pretend they return an invalid php version
         expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the ubuntu version is not gotten because we already have it specified in the settings
+	expect(subject).to receive(:get_ubuntu_version).never
 	# check if the settings we write back to disk have an unaltered box (name) and box_url
         expect(subject).to receive(:update_settings).once.with(retrieved_settings)
       end

--- a/vagrant/plugins/vagrant-hypconfigmgmt/spec/unit/command/get_ubuntu_version_spec.rb
+++ b/vagrant/plugins/vagrant-hypconfigmgmt/spec/unit/command/get_ubuntu_version_spec.rb
@@ -1,0 +1,55 @@
+# -*- encoding: utf-8 -*-
+# vim: set fileencoding=utf-8
+
+require 'spec_helper'
+require "vagrant-hypconfigmgmt/command"
+
+describe VagrantHypconfigmgmt::Command do
+  # create a fake app and env to pass into the VagrantHypconfigmgmt::Command constructor
+  let(:app) { }
+  let(:env) { { :ui => ui } }
+
+  # pretend env contains the Vagrant ui element
+  let(:ui) do
+    double('ui').tap do |ui|
+      allow(ui).to receive(:info) { nil }
+    end
+  end
+
+
+  # instantiate class of which a method is to be tested
+  subject { described_class.new(app, env) }
+
+  # the method that we are going to test
+  describe "#ubuntu_version" do
+
+    context "when the user inputs ubuntu version precise" do
+      it "returns ubuntu version precise" do
+	# check if the setting is prompted for and pretend it returns a "precise" answer
+        expect(subject).to receive(:get_setting).with(
+	  env, AVAILABLE_UBUNTU_VERSIONS, DEFAULT_UBUNTU_VERSION,
+	  "What Ubuntu version do you want to use? Options: xenial, precise (deprecated) [default #{DEFAULT_UBUNTU_VERSION}]: "
+	).and_return("precise")
+        # check a message is printed about the ubuntu version
+        expect(ui).to receive(:info).once.with(/.*Precise.*deprecated.*/)
+	# check if the function returns "precise" 
+        expect( subject.get_ubuntu_version(env) ).to eq("precise")
+      end
+    end
+
+    context "when the user inputs ubuntu version xenial" do
+      it "returns ubuntu version xenial" do
+	# check if the setting is prompted for and pretend it returns a "virtualbox" answer
+        expect(subject).to receive(:get_setting).with(
+	  env, AVAILABLE_UBUNTU_VERSIONS, DEFAULT_UBUNTU_VERSION,
+	  "What Ubuntu version do you want to use? Options: xenial, precise (deprecated) [default #{DEFAULT_UBUNTU_VERSION}]: "
+	).and_return("xenial")
+        # check a message is printed about the ubuntu version
+        expect(ui).to receive(:info).once.with(/.*Xenial.*default.*/)
+	# check if the function returns "xenial" 
+        expect( subject.get_ubuntu_version(env) ).to eq("xenial")
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Booting a Xenial hypernode-vagrant
```
vdloo@workstation4:~/code/projects/hypernode-vagrant$ vagrant up 
Bringing machine 'hypernode' up with 'virtualbox' provider...
...
    hypernode: What Ubuntu version do you want to use? Options: xenial, precise (deprecated) [default xenial]: 
==> hypernode: Will use the Xenial version
==> hypernode: Your hypernode-vagrant is now configured. Please run "vagrant up" again.
```
