### PR TITLE
switch php version during post provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,7 +71,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
            -f #{settings['firewall']['state']} \
            -c #{settings['cgroup']['state']} \
            -x #{settings['xdebug']['state']} \
-           -d #{settings['hostmanager']['default_domain']}" \
+           -d #{settings['hostmanager']['default_domain']} \
+           -p #{settings['php']['version']}" \
 
     config.vm.provider :virtualbox do |vbox, override|
       override.vm.network "private_network", type: "dhcp"

--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-while getopts "m:v:f:c:x:d:" opt; do
+while getopts "m:v:f:c:x:d:p:" opt; do
     case "$opt" in
         m)
             magento_version="$OPTARG" ;;
@@ -17,6 +17,8 @@ while getopts "m:v:f:c:x:d:" opt; do
             xdebug_enabled="$OPTARG" ;;
         d)
             default_domain="$OPTARG" ;;
+        p)
+            php_version="$OPTARG" ;;
     esac
 done
 
@@ -73,64 +75,69 @@ if ! find /data/web/public/ -mindepth 1 -name '*.php' -name '*.html' | read; the
     chown -R $user:$user /data/web/public
 fi
 
-# Start the correct FPM
-which php5 && PHP_VERSION="php5" || /bin/true
-which php7.0 && PHP_VERSION="php7.0" || /bin/true
-which hypernode-switch-php && hypernode-switch-php ${PHP_VERSION/php/} || /bin/true
+# Start the correct FPM daemon
+hypernode-switch-php $php_version
 
-if $xdebug_enabled; then
-    XDEBUG_RELEASE="https://xdebug.org/files/xdebug-2.5.0rc1.tgz"
-    echo "Ensuring Xdebug is installed"
-
-    # Install Xdebug for retrieving extended debug information and 
-    # stacktraces from your development environment.
-
-    if [ -z $PHP_VERSION ]; then
-        echo "No supported PHP version found for this xdebug installation script. Skipping.."
-	break
+if grep -q xenial /etc/lsb-release; then
+	echo "Xdebug not implemented for Xenial at this point in time."
+	echo "Need this? Please let us know on https://github.com/ByteInternet/hypernode-vagrant/issues"
+else
+    if $xdebug_enabled; then
+        XDEBUG_RELEASE="https://xdebug.org/files/xdebug-2.5.0rc1.tgz"
+        echo "Ensuring Xdebug is installed"
+    
+        # Install Xdebug for retrieving extended debug information and 
+        # stacktraces from your development environment.
+        which php5 && PHP_VERSION="php5" || /bin/true
+        which php7.0 && PHP_VERSION="php7.0" || /bin/true
+    
+        if [ -z $PHP_VERSION ]; then
+            echo "No supported PHP version found for this xdebug installation script. Skipping.."
+    	break
+        fi
+    
+        # Download the configured release
+        if [ ! -f /tmp/xdebug.tgz ]; then
+            # Install the required package(s)
+            apt-get update
+            apt-get install ${PHP_VERSION}-dev -yy
+    
+            # Unpack Xdebug
+            wget -q -nc -O /tmp/xdebug.tgz $XDEBUG_RELEASE
+            cd /tmp
+            tar -xvzf xdebug.tgz
+    	cd xdebug-*
+    
+            # Build Xdebug from source
+            /usr/bin/phpize
+            ./configure
+            make
+            [ "$PHP_VERSION" == "php5" ] && MODULES_DIR="/usr/lib/php5/20121212/"
+            [ "$PHP_VERSION" == "php7.0" ] && MODULES_DIR="/usr/lib/php/20151012/"
+            cp -f modules/xdebug.so $MODULES_DIR
+    
+            [ "$PHP_VERSION" == "php5" ] && PHP_DIR="/etc/php5/"
+            [ "$PHP_VERSION" == "php7.0" ] && PHP_DIR="/etc/php/7.0/"
+    
+            # Configure PHP to load xdebug.so
+            for i in fpm cli; do
+                EXTENSION_CONFIG="zend_extension = ${MODULES_DIR}xdebug.so"
+    	    touch ${PHP_DIR}${i}/conf.d/10-xdebug.ini
+        	    grep -q "$EXTENSION_CONFIG" ${PHP_DIR}${i}/conf.d/10-xdebug.ini || \
+        	        echo -n "$EXTENSION_CONFIG" > ${PHP_DIR}${i}/conf.d/10-xdebug.ini
+            done
+    
+            # Restart PHP and Nginx
+            [ "$PHP_VERSION" == "php5" ] && service php5-fpm restart
+            [ "$PHP_VERSION" == "php7.0" ] && service php7.0-fpm restart
+            service nginx restart
+    
+        fi
+        echo ""
+        echo "Xdebug is installed. To configure Xdebug to send metrics to"
+        echo "your IDE, see the 'Configuring Xdebug to send metrics section in "
+        echo "this article: https://support.hypernode.com/knowledgebase/install-xdebug-hypernode-vagrant/"
     fi
-
-    # Download the configured release
-    if [ ! -f /tmp/xdebug.tgz ]; then
-        # Install the required package(s)
-        apt-get update
-        apt-get install ${PHP_VERSION}-dev -yy
-
-        # Unpack Xdebug
-        wget -q -nc -O /tmp/xdebug.tgz $XDEBUG_RELEASE
-        cd /tmp
-        tar -xvzf xdebug.tgz
-	cd xdebug-*
-
-        # Build Xdebug from source
-        /usr/bin/phpize
-        ./configure
-        make
-        [ "$PHP_VERSION" == "php5" ] && MODULES_DIR="/usr/lib/php5/20121212/"
-        [ "$PHP_VERSION" == "php7.0" ] && MODULES_DIR="/usr/lib/php/20151012/"
-        cp -f modules/xdebug.so $MODULES_DIR
-
-        [ "$PHP_VERSION" == "php5" ] && PHP_DIR="/etc/php5/"
-        [ "$PHP_VERSION" == "php7.0" ] && PHP_DIR="/etc/php/7.0/"
-
-        # Configure PHP to load xdebug.so
-        for i in fpm cli; do
-            EXTENSION_CONFIG="zend_extension = ${MODULES_DIR}xdebug.so"
-	    touch ${PHP_DIR}${i}/conf.d/10-xdebug.ini
-    	    grep -q "$EXTENSION_CONFIG" ${PHP_DIR}${i}/conf.d/10-xdebug.ini || \
-    	        echo -n "$EXTENSION_CONFIG" > ${PHP_DIR}${i}/conf.d/10-xdebug.ini
-        done
-
-        # Restart PHP and Nginx
-        [ "$PHP_VERSION" == "php5" ] && service php5-fpm restart
-        [ "$PHP_VERSION" == "php7.0" ] && service php7.0-fpm restart
-        service nginx restart
-
-    fi
-    echo ""
-    echo "Xdebug is installed. To configure Xdebug to send metrics to"
-    echo "your IDE, see the 'Configuring Xdebug to send metrics section in "
-    echo "this article: https://support.hypernode.com/knowledgebase/install-xdebug-hypernode-vagrant/"
 fi
 
 if ! $varnish_enabled; then 

--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -78,11 +78,11 @@ fi
 # Start the correct FPM daemon
 hypernode-switch-php $php_version
 
-if grep -q xenial /etc/lsb-release; then
-	echo "Xdebug not implemented for Xenial at this point in time."
-	echo "Need this? Please let us know on https://github.com/ByteInternet/hypernode-vagrant/issues"
-else
-    if $xdebug_enabled; then
+if $xdebug_enabled; then
+    if grep -q xenial /etc/lsb-release; then
+    	echo "Xdebug not implemented for Xenial at this point in time."
+    	echo "Need this? Please let us know on https://github.com/ByteInternet/hypernode-vagrant/issues"
+    else
         XDEBUG_RELEASE="https://xdebug.org/files/xdebug-2.5.0rc1.tgz"
         echo "Ensuring Xdebug is installed"
     

--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -73,14 +73,17 @@ if ! find /data/web/public/ -mindepth 1 -name '*.php' -name '*.html' | read; the
     chown -R $user:$user /data/web/public
 fi
 
+# Start the correct FPM
+which php5 && PHP_VERSION="php5" || /bin/true
+which php7.0 && PHP_VERSION="php7.0" || /bin/true
+which hypernode-switch-php && hypernode-switch-php ${PHP_VERSION/php/} || /bin/true
+
 if $xdebug_enabled; then
     XDEBUG_RELEASE="https://xdebug.org/files/xdebug-2.5.0rc1.tgz"
     echo "Ensuring Xdebug is installed"
 
     # Install Xdebug for retrieving extended debug information and 
     # stacktraces from your development environment.
-    which php5 && PHP_VERSION="php5" || /bin/true
-    which php7.0 && PHP_VERSION="php7.0" || /bin/true
 
     if [ -z $PHP_VERSION ]; then
         echo "No supported PHP version found for this xdebug installation script. Skipping.."


### PR DESCRIPTION
no 2 images anymore for php5.5 and 7.0, both are installed in the same
image now and can be switched with hypernode-switch-php. Precise
hypernode-vagrant will still use separate images.

edit: oh right that won't work obviously, need to pass the php version from the provisioner into the script
edit2: building Xdebug on the Xenial image is not implemented for now

Switching PHP versions without re-creating the box:
```
vdloo@workstation4:~/code/projects/hypernode-vagrant$ sed -i 's/5.5/7.0/g' local.yml
vdloo@workstation4:~/code/projects/hypernode-vagrant$ vagrant provision
==> hypernode: Running provisioner: shell...
    hypernode: Running: /tmp/vagrant-shell20170413-31217-qodcfk.sh
==> hypernode: mesg: 
==> hypernode: ttyname failed
==> hypernode: : 
==> hypernode: Inappropriate ioctl for device
==> hypernode: No LSB modules are available.
==> hypernode: Synchronizing state of php5.5-fpm.service with SysV init with /lib/systemd/systemd-sysv-install...
==> hypernode: Executing /lib/systemd/systemd-sysv-install disable php5.5-fpm
==> hypernode: insserv: warning: current start runlevel(s) (empty) of script `php5.5-fpm' overrides LSB defaults (2 3 4 5).
==> hypernode: insserv: warning: current stop runlevel(s) (0 1 2 3 4 5 6) of script `php5.5-fpm' overrides LSB defaults (0 1 6).
==> hypernode: update-alternatives: 
==> hypernode: using /usr/bin/php7.0 to provide /usr/bin/php (php) in manual mode
==> hypernode: Synchronizing state of php7.0-fpm.service with SysV init with /lib/systemd/systemd-sysv-install...
==> hypernode: Executing /lib/systemd/systemd-sysv-install enable php7.0-fpm
==> hypernode: insserv: warning: current start runlevel(s) (empty) of script `php7.0-fpm' overrides LSB defaults (2 3 4 5).
==> hypernode: insserv: warning: current stop runlevel(s) (0 1 2 3 4 5 6) of script `php7.0-fpm' overrides LSB defaults (0 1 6).
==> hypernode: Xdebug not implemented for Xenial at this point in time.
==> hypernode: Need this? Please let us know on https://github.com/ByteInternet/hypernode-vagrant/issues
==> hypernode: Your hypernode-vagrant is ready! Log in with:
==> hypernode: ssh app@hypernode.local -oStrictHostKeyChecking=no -A
==> hypernode: Or visit http://projects.hypernode.local in your browser
vdloo@workstation4:~/code/projects/hypernode-vagrant$ vagrant ssh -c 'php -v'
PHP 7.0.17-3 (cli) (built: Mar 22 2017 13:43:47) ( NTS )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.0.0, Copyright (c) 1998-2017 Zend Technologies
    with Zend OPcache v7.0.17-3, Copyright (c) 1999-2017, by Zend Technologies
Connection to 127.0.0.1 closed.
vdloo@workstation4:~/code/projects/hypernode-vagrant$ sed -i 's/7.0/5.5/g' local.yml
vdloo@workstation4:~/code/projects/hypernode-vagrant$ vagrant provision
==> hypernode: Running provisioner: shell...
    hypernode: Running: /tmp/vagrant-shell20170413-31590-1yi66v1.sh
==> hypernode: mesg: 
==> hypernode: ttyname failed
==> hypernode: : 
==> hypernode: Inappropriate ioctl for device
==> hypernode: No LSB modules are available.
==> hypernode: Synchronizing state of php7.0-fpm.service with SysV init with /lib/systemd/systemd-sysv-install...
==> hypernode: Executing /lib/systemd/systemd-sysv-install disable php7.0-fpm
==> hypernode: insserv: warning: current start runlevel(s) (empty) of script `php7.0-fpm' overrides LSB defaults (2 3 4 5).
==> hypernode: insserv: warning: current stop runlevel(s) (0 1 2 3 4 5 6) of script `php7.0-fpm' overrides LSB defaults (0 1 6).
==> hypernode: update-alternatives: 
==> hypernode: using /usr/bin/php5.5 to provide /usr/bin/php (php) in manual mode
==> hypernode: Synchronizing state of php5.5-fpm.service with SysV init with /lib/systemd/systemd-sysv-install...
==> hypernode: Executing /lib/systemd/systemd-sysv-install enable php5.5-fpm
==> hypernode: insserv: warning: current start runlevel(s) (empty) of script `php5.5-fpm' overrides LSB defaults (2 3 4 5).
==> hypernode: insserv: warning: current stop runlevel(s) (0 1 2 3 4 5 6) of script `php5.5-fpm' overrides LSB defaults (0 1 6).
==> hypernode: Xdebug not implemented for Xenial at this point in time.
==> hypernode: Need this? Please let us know on https://github.com/ByteInternet/hypernode-vagrant/issues
==> hypernode: Your hypernode-vagrant is ready! Log in with:
==> hypernode: ssh app@hypernode.local -oStrictHostKeyChecking=no -A
==> hypernode: Or visit http://projects.hypernode.local in your browser
vdloo@workstation4:~/code/projects/hypernode-vagrant$ vagrant ssh -c 'php -v'
PHP 5.5.38-4 (cli) 
Copyright (c) 1997-2015 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2015 Zend Technologies
    with the ionCube PHP Loader (enabled) + Intrusion Protection from ioncube24.com (unconfigured) v5.1.2, Copyright (c) 2002-2016, by ionCube Ltd.
    with Zend OPcache v7.0.6-dev, Copyright (c) 1999-2015, by Zend Technologies
Connection to 127.0.0.1 closed.
```