### PR TITLE
print vagrant up error in hypernode-vagrant-error

### DIFF
--- a/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/utils.py
+++ b/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/utils.py
@@ -1,7 +1,7 @@
 from sys import stdout
 from logging import getLogger
 from os import geteuid
-from subprocess import check_call, check_output
+from subprocess import check_call, check_output, CalledProcessError
 
 log = getLogger(__name__)
 
@@ -57,6 +57,13 @@ def run_local_command(command, shell=False):
     the command as a list instead of a string
     :return str output: The output
     """
-    output = check_output(command, shell=shell)
+    try:
+        output = check_output(command, shell=shell)
+    except CalledProcessError as e:
+        log.warning("Running command failed: {}".format(command))
+        write_output_to_stdout(e.output)
+        if hasattr(e, 'stderr'):
+            write_output_to_stdout(e.stderr)
+        raise
     write_output_to_stdout(output)
     return output.decode('utf-8') if is_python_3() else output


### PR DESCRIPTION
Currently it is not very clear why vagrant up fails if it does in the hypernode-vagrant-runner
```
+ ./build.sh -1
Building PHP 7.0 FOR amd64 xenial
Creating a new checkout of hypernode-vagrant-runner in /tmp/hypernode-vagrant-runner
Cloning into '/tmp/hypernode-vagrant-runner'...
Ensuring directory for checkout
Cloning hypernode-vagrant
Cloning into '/srv/jenkins/workspace/build-xenial-PHP-debs/php/hypernode-vagrant'...
Ensuring Vagrant plugin vagrant-vbguest is installed
vagrant-vbguest (0.11.0)
Ensuring Vagrant plugin vagrant-hypconfigmgmt is installed
vagrant-hypconfigmgmt (0.0.8)
Writing configuration file to the hypernode-vagrant directory
Running 'vagrant up' in the hypernode-vagrant checkout directory. This can take a while.
sudo: no tty present and no askpass program specified
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
Traceback (most recent call last):
  File "/tmp/hypernode-vagrant-runner/tools/hypernode-vagrant-runner/bin/start_runner.py", line 5, in <module>
    start_runner()
  File "/tmp/hypernode-vagrant-runner/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/commands.py", line 107, in start_runner
    no_provision=args.no_provision
  File "/tmp/hypernode-vagrant-runner/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/runner/__init__.py", line 104, in launch_runner
    xenial=xenial, no_provision=no_provision
  File "/usr/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/tmp/hypernode-vagrant-runner/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/vagrant/__init__.py", line 57, in hypernode_vagrant
    xenial=xenial, no_provision=no_provision
  File "/tmp/hypernode-vagrant-runner/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/vagrant/set_up.py", line 177, in create_hypernode_vagrant
    no_provision=no_provision
  File "/tmp/hypernode-vagrant-runner/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/vagrant/set_up.py", line 148, in start_hypernode_vagrant
    run_vagrant_up(directory, no_provision=no_provision)
  File "/tmp/hypernode-vagrant-runner/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/vagrant/set_up.py", line 95, in run_vagrant_up
    run_local_command(start_vagrant, shell=True)
  File "/tmp/hypernode-vagrant-runner/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/utils.py", line 60, in run_local_command
    output = check_output(command, shell=shell)
  File "/usr/lib/python2.7/subprocess.py", line 573, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command 'cd /srv/jenkins/workspace/build-xenial-PHP-debs/php/hypernode-vagrant && vagrant up' returned non-zero exit status 1
Build step 'Execute shell' marked build as failure
```

After:
```
Running command failed: cd /srv/jenkins/workspace/build-xenial-PHP-debs/php/hypernode-vagrant && vagrant up
Bringing machine 'hypernode' up with 'lxc' provider...
==> hypernode: 'Tip: run "vagrant plugin install vagrant-gatling-rsync" to speed up 
==> hypernode: shared folder operations.
==> hypernode: You can then sync with "vagrant gatling-rsync-auto"
==> hypernode: instead of "vagrant rsync-auto" to increase performance
==> hypernode: Importing base box 'hypernode_xenial'...
==> hypernode: Checking if box 'hypernode_xenial' is up to date...
==> hypernode: A newer version of the box 'hypernode_xenial' is available! You currently
==> hypernode: have version '3847'. The latest is version '3925'. Run
==> hypernode: `vagrant box update` to update.
==> hypernode: Setting up mount entries for shared folders...
    hypernode: /vagrant => /srv/jenkins/workspace/build-xenial-PHP-debs/php/hypernode-vagrant
==> hypernode: Starting container...
==> hypernode: Waiting for machine to boot. This may take a few minutes...
    hypernode: SSH address: 10.0.3.254:22
    hypernode: SSH username: vagrant
    hypernode: SSH auth method: private key
    hypernode: 
    hypernode: Vagrant insecure key detected. Vagrant will automatically replace
    hypernode: this with a newly generated keypair for better security.
    hypernode: 
    hypernode: Inserting generated public key within guest...
    hypernode: Removing insecure key from the guest if it's present...
    hypernode: Key inserted! Disconnecting and reconnecting using new SSH key...
==> hypernode: Machine booted and ready!
==> hypernode: Setting hostname...
==> hypernode: Updating /etc/hosts file on active guest machines...
==> hypernode: Updating /etc/hosts file on host machine (password may be required)...
==> hypernode: Running provisioner: shell...
    hypernode: Running: /tmp/vagrant-shell20170414-17627-1efnrvd.sh
==> hypernode: mesg: ttyname failed: Inappropriate ioctl for device
==> hypernode: /tmp/vagrant-shell: line 79: hypernode-switch-php: command not found
```