### PR TITLE
only run hypernode-switch-php if installed

### DIFF
--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -76,7 +76,7 @@ if ! find /data/web/public/ -mindepth 1 -name '*.php' -name '*.html' | read; the
 fi
 
 # Start the correct FPM daemon
-hypernode-switch-php $php_version
+command -v hypernode-switch-php >/dev/null 2>&1 && hypernode-switch-php $php_version || /bin/true
 
 if $xdebug_enabled; then
     if grep -q xenial /etc/lsb-release; then


### PR DESCRIPTION
currently not in the virtualbox image yet, skipping this for now. if you
want to switch to a different php before a new virtualbox image becomes
available, apt-get upgrade and run it manually.