### PR TITLE
fix ip resolver for xenial

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -102,8 +102,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       config.hostmanager.ip_resolver = proc do |vm, resolving_vm|
         if vm.communicate.ready?
           result = ""
-          vm.communicate.execute("ifconfig `find /sys/class/net -name 'eth*' -printf '%f\n' | tail -n 1`") do |type, data|
+          vm.communicate.execute("ifconfig `find /sys/class/net \\\( -name 'eth*' -o -name 'enp*' \\\) -printf '%f\n' | sort | tail -n 1`") do |type, data|
             result << data if type == :stdout
+	    puts result
           end
         end
         (ip = /inet addr:(\d+\.\d+\.\d+\.\d+)/.match(result)) && ip[1]


### PR DESCRIPTION
We upgraded to Xenial recently where the network interface layout is a bit different:

```
vagrant@beb7b8-projects-magweb-vgr:~$ ip addr
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: enp0s3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 08:00:27:c3:0a:85 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 brd 10.0.2.255 scope global enp0s3
       valid_lft forever preferred_lft forever
3: enp0s8: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 08:00:27:5b:ca:2b brd ff:ff:ff:ff:ff:ff
    inet 172.28.128.3/24 brd 172.28.128.255 scope global enp0s8
       valid_lft forever preferred_lft forever
```

Previously on precise it looked like this:
```
vagrant@beb7b8-projects-magweb-vgr:~$ ip addr
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 08:00:27:88:0c:a6 brd ff:ff:ff:ff:ff:ff
    inet 10.0.2.15/24 brd 10.0.2.255 scope global eth0
       valid_lft forever preferred_lft forever
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP qlen 1000
    link/ether 08:00:27:cd:10:81 brd ff:ff:ff:ff:ff:ff
    inet 172.28.128.4/24 brd 172.28.128.255 scope global eth1
       valid_lft forever preferred_lft forever
```

It goes wrong [here](https://github.com/ByteInternet/hypernode-vagrant/blob/master/Vagrantfile#L105).

This line:
```
ifconfig `find /sys/class/net -name 'eth*' -printf '%f\n' | tail -n 1`
```

Now returns nothing for the find so ifconfig will list all interfaces and the regex will match the wrong one (which isn't the shared interface).

Instead we should also find the enp* interfaces like so:

```
ifconfig `find /sys/class/net \( -name 'eth*' -o -name 'enp*' \) -printf '%f\n' | sort | tail -n 1
```

Also see https://github.com/devopsgroup-io/vagrant-hostmanager/issues/86#issuecomment-183265949