### PR TITLE
prepare hypernode-vagrant for php5.6 on Xenial

### DIFF
--- a/vagrant/plugins/vagrant-hypconfigmgmt/lib/vagrant-hypconfigmgmt/command.rb
+++ b/vagrant/plugins/vagrant-hypconfigmgmt/lib/vagrant-hypconfigmgmt/command.rb
@@ -5,7 +5,7 @@ DEFAULT_MAGENTO_VERSION = 2
 AVAILABLE_MAGENTO_VERSIONS = [1, 2]
 
 DEFAULT_PHP_VERSION = 7.0
-AVAILABLE_PHP_VERSIONS = [5.5, 7.0]
+AVAILABLE_PHP_VERSIONS = [5.5, 5.6, 7.0]
 
 DEFAULT_VARNISH_STATE = false
 AVAILABLE_VARNISH_STATES = [true, false]
@@ -292,6 +292,10 @@ HEREDOC
         settings['vagrant']['box'] = 'hypernode_xenial'
         settings['vagrant']['box_url'] = 'http://vagrant.hypernode.com/customer/xenial/catalog.json'
       else
+        if settings['php']['version'] == 5.6
+          env[:ui].warning("The Precise Hypernodes don't have PHP5.6. Falling back to 5.5. Use the Xenial version of this box if you want PHP5.6")
+          settings['php']['version'] = 5.5
+        end
         case settings['php']['version']
           when 5.5
             env[:ui].info("Will use PHP 5.5. If you want PHP 7 instead change the php version in local.yml.")

--- a/vagrant/plugins/vagrant-hypconfigmgmt/spec/unit/command/ensure_vagrant_box_type_configured_spec.rb
+++ b/vagrant/plugins/vagrant-hypconfigmgmt/spec/unit/command/ensure_vagrant_box_type_configured_spec.rb
@@ -13,6 +13,7 @@ describe VagrantHypconfigmgmt::Command do
   let(:ui) do
     double('ui').tap do |ui|
       allow(ui).to receive(:info) { nil }
+      allow(ui).to receive(:warning) { nil }
     end
   end
 
@@ -156,6 +157,80 @@ describe VagrantHypconfigmgmt::Command do
 	expect(subject).to receive(:get_ubuntu_version).never
 	# check if the settings that are written back to disk contain the right box (name) and box_url
         expect(subject).to receive(:update_settings).once.with(expected_settings)
+      end
+    end
+
+    context "when php 5.6 is configured but no ubuntu version specified" do
+      let(:retrieved_settings) { { "php" => { "version" => 5.6 }, "vagrant" => Hash.new } }
+      it "sets the box name and box url to the right values for PHP 5.6" do
+	expected_settings = { 
+          "ubuntu_version" => "precise",
+          "php" => { 
+	    "version" => 5.5
+	  },
+	  "vagrant" => { 
+            # Falling back to php5.5, Precise Hypernodes have no PHP5.6
+	    "box" => "hypernode_php5", 
+	    "box_url" => "http://vagrant.hypernode.com/customer/php5/catalog.json" 
+	  } 
+	}
+	# check if settings are retrieved from disk and pretend they return a configuration for php 5.5
+        expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the ubuntu version is gotten and pretend it returns precise
+	expect(subject).to receive(:get_ubuntu_version).once.with(env).and_return('precise')
+	# check if the settings that are written back to disk contain the right box (name) and box_url
+        expect(subject).to receive(:update_settings).once.with(expected_settings)
+	# check if the user is warned about falling back to 5.5
+	expect(ui).to receive(:warning).once.with(/.*Falling back to 5.5*/)
+      end
+    end
+
+    context "when php 5.6 is configured and precise ubuntu version specified" do
+      let(:retrieved_settings) { { "php" => { "version" => 5.6 }, "vagrant" => Hash.new, "ubuntu_version" => "precise" } }
+      it "sets the box name and box url to the right values for PHP 5.5" do
+	expected_settings = { 
+          "ubuntu_version" => "precise",
+          "php" => { 
+            # Falling back to php5.5, Precise Hypernodes have no PHP5.6
+	    "version" => 5.5 
+	  }, 
+	  "vagrant" => { 
+	    "box" => "hypernode_php5", 
+	    "box_url" => "http://vagrant.hypernode.com/customer/php5/catalog.json" 
+	  } 
+	}
+	# check if settings are retrieved from disk and pretend they return a configuration for php 5.5
+        expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the ubuntu version is not gotten because we already have it specified in the settings
+	expect(subject).to receive(:get_ubuntu_version).never
+	# check if the settings that are written back to disk contain the right box (name) and box_url
+        expect(subject).to receive(:update_settings).once.with(expected_settings)
+	# check if the user is warned about falling back to 5.5
+	expect(ui).to receive(:warning).once.with(/.*Falling back to 5.5*/)
+      end
+    end
+
+    context "when php 5.6 is configured and xenial ubuntu version specified" do
+      let(:retrieved_settings) { { "php" => { "version" => 5.6 }, "vagrant" => Hash.new, "ubuntu_version" => "xenial" } }
+      it "sets the box name and box url to the right values for PHP 5.6" do
+	expected_settings = { 
+          "ubuntu_version" => "xenial",
+          "php" => { 
+	    "version" => 5.6
+	  }, 
+	  "vagrant" => { 
+	    "box" => "hypernode_xenial", 
+	    "box_url" => "http://vagrant.hypernode.com/customer/xenial/catalog.json" 
+	  } 
+	}
+	# check if settings are retrieved from disk and pretend they return a configuration for php 5.5
+        expect(subject).to receive(:retrieve_settings).once.with(no_args).and_return(retrieved_settings)
+	# check if the ubuntu version is not gotten because we already have it specified in the settings
+	expect(subject).to receive(:get_ubuntu_version).never
+	# check if the settings that are written back to disk contain the right box (name) and box_url
+        expect(subject).to receive(:update_settings).once.with(expected_settings)
+	# check that the user is not warned about falling back because we do have 5.6 on Xenial
+	expect(ui).to receive(:warning).never
       end
     end
 

--- a/vagrant/plugins/vagrant-hypconfigmgmt/spec/unit/command/get_options_string_spec.rb
+++ b/vagrant/plugins/vagrant-hypconfigmgmt/spec/unit/command/get_options_string_spec.rb
@@ -34,7 +34,7 @@ describe VagrantHypconfigmgmt::Command do
 
     context "when the options are floats" do
       it "it casts the floats to strings and returns them separated by 'or'" do
-        expect( subject.get_options_string([5.5, 7.0]) ).to eq("5.5 or 7.0")
+        expect( subject.get_options_string([5.5, 5.6, 7.0]) ).to eq("5.5 or 5.6 or 7.0")
       end
     end
 

--- a/vagrant/plugins/vagrant-hypconfigmgmt/spec/unit/command/get_php_version_spec.rb
+++ b/vagrant/plugins/vagrant-hypconfigmgmt/spec/unit/command/get_php_version_spec.rb
@@ -38,6 +38,21 @@ describe VagrantHypconfigmgmt::Command do
     end
 
 
+    context "when PHP 5.6 is configured" do
+      it "it notifies the user that PHP 5.6 will be used and returns the value" do
+	# check if the setting is prompted for and pretend it returns a "PHP 5.6" answer
+        expect(subject).to receive(:get_setting).with(
+	  env, AVAILABLE_PHP_VERSIONS, DEFAULT_PHP_VERSION,
+	  "Is this a PHP #{subject.get_options_string(AVAILABLE_PHP_VERSIONS)} Hypernode? [default #{DEFAULT_PHP_VERSION}]: "
+	).and_return("5.6")
+        # check if the user is notified about the PHP version
+        expect(ui).to receive(:info).once.with(/.*PHP 5.6*/)
+	# check if the function returns float 5.5 if a PHP 5.5 Vagrant is to be used
+        expect( subject.get_php_version(env) ).to eq(5.6)
+      end
+    end
+
+
     context "when PHP 7.0 is configured" do
       it "it notifies the user that PHP 7.0 will be used and returns the value" do
 	# check if the setting is prompted for and pretend it returns a "PHP 7.0" answer

--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -89,6 +89,8 @@ if $xdebug_enabled; then
         # Install Xdebug for retrieving extended debug information and 
         # stacktraces from your development environment.
         which php5 && PHP_VERSION="php5" || /bin/true
+        which php5.5 && PHP_VERSION="php5" || /bin/true
+        which php5.6 && PHP_VERSION="php5.6" || /bin/true
         which php7.0 && PHP_VERSION="php7.0" || /bin/true
     
         if [ -z $PHP_VERSION ]; then
@@ -113,10 +115,14 @@ if $xdebug_enabled; then
             ./configure
             make
             [ "$PHP_VERSION" == "php5" ] && MODULES_DIR="/usr/lib/php5/20121212/"
+            [ "$PHP_VERSION" == "php5.5" ] && MODULES_DIR="/usr/lib/php5/20121212/"
+            [ "$PHP_VERSION" == "php5.6" ] && MODULES_DIR="/usr/lib/php5/20131226/"
             [ "$PHP_VERSION" == "php7.0" ] && MODULES_DIR="/usr/lib/php/20151012/"
             cp -f modules/xdebug.so $MODULES_DIR
     
             [ "$PHP_VERSION" == "php5" ] && PHP_DIR="/etc/php5/"
+            [ "$PHP_VERSION" == "php5.5" ] && PHP_DIR="/etc/php/5.5/"
+            [ "$PHP_VERSION" == "php5.6" ] && PHP_DIR="/etc/php/5.6/"
             [ "$PHP_VERSION" == "php7.0" ] && PHP_DIR="/etc/php/7.0/"
     
             # Configure PHP to load xdebug.so
@@ -129,6 +135,8 @@ if $xdebug_enabled; then
     
             # Restart PHP and Nginx
             [ "$PHP_VERSION" == "php5" ] && service php5-fpm restart
+            [ "$PHP_VERSION" == "php5.5" ] && service php5.5-fpm restart
+            [ "$PHP_VERSION" == "php5.6" ] && service php5.6-fpm restart
             [ "$PHP_VERSION" == "php7.0" ] && service php7.0-fpm restart
             service nginx restart
     


### PR DESCRIPTION
so we can start building our PHP modules in our CI for PHP5.6