### PR TITLE
add xdebug install to xenial provisioning

### DIFF
--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -81,7 +81,7 @@ command -v hypernode-switch-php >/dev/null 2>&1 && hypernode-switch-php $php_ver
 if $xdebug_enabled; then
     if grep -q xenial /etc/lsb-release; then
         echo "Installing xdebug"
-	apt-get update
+        apt-get update
         apt-get install varnish php-xdebug -y \
           -q -o Dpkg::Options::="--force-confdef" \
           -o Dpkg::Options::="--force-confold"
@@ -98,7 +98,7 @@ if $xdebug_enabled; then
     
         if [ -z $PHP_VERSION ]; then
             echo "No supported PHP version found for this xdebug installation script. Skipping.."
-    	break
+        break
         fi
     
         # Download the configured release
@@ -111,7 +111,7 @@ if $xdebug_enabled; then
             wget -q -nc -O /tmp/xdebug.tgz $XDEBUG_RELEASE
             cd /tmp
             tar -xvzf xdebug.tgz
-    	cd xdebug-*
+        cd xdebug-*
     
             # Build Xdebug from source
             /usr/bin/phpize
@@ -131,9 +131,9 @@ if $xdebug_enabled; then
             # Configure PHP to load xdebug.so
             for i in fpm cli; do
                 EXTENSION_CONFIG="zend_extension = ${MODULES_DIR}xdebug.so"
-    	    touch ${PHP_DIR}${i}/conf.d/10-xdebug.ini
-        	    grep -q "$EXTENSION_CONFIG" ${PHP_DIR}${i}/conf.d/10-xdebug.ini || \
-        	        echo -n "$EXTENSION_CONFIG" > ${PHP_DIR}${i}/conf.d/10-xdebug.ini
+                touch ${PHP_DIR}${i}/conf.d/10-xdebug.ini
+                grep -q "$EXTENSION_CONFIG" ${PHP_DIR}${i}/conf.d/10-xdebug.ini || \
+                    echo -n "$EXTENSION_CONFIG" > ${PHP_DIR}${i}/conf.d/10-xdebug.ini
             done
     
         fi

--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -80,8 +80,11 @@ command -v hypernode-switch-php >/dev/null 2>&1 && hypernode-switch-php $php_ver
 
 if $xdebug_enabled; then
     if grep -q xenial /etc/lsb-release; then
-    	echo "Xdebug not implemented for Xenial at this point in time."
-    	echo "Need this? Please let us know on https://github.com/ByteInternet/hypernode-vagrant/issues"
+        echo "Installing xdebug"
+	apt-get update
+        apt-get install varnish php-xdebug -y \
+          -q -o Dpkg::Options::="--force-confdef" \
+          -o Dpkg::Options::="--force-confold"
     else
         XDEBUG_RELEASE="https://xdebug.org/files/xdebug-2.5.0rc1.tgz"
         echo "Ensuring Xdebug is installed"
@@ -133,19 +136,18 @@ if $xdebug_enabled; then
         	        echo -n "$EXTENSION_CONFIG" > ${PHP_DIR}${i}/conf.d/10-xdebug.ini
             done
     
-            # Restart PHP and Nginx
-            [ "$PHP_VERSION" == "php5" ] && service php5-fpm restart
-            [ "$PHP_VERSION" == "php5.5" ] && service php5.5-fpm restart
-            [ "$PHP_VERSION" == "php5.6" ] && service php5.6-fpm restart
-            [ "$PHP_VERSION" == "php7.0" ] && service php7.0-fpm restart
-            service nginx restart
-    
         fi
-        echo ""
-        echo "Xdebug is installed. To configure Xdebug to send metrics to"
-        echo "your IDE, see the 'Configuring Xdebug to send metrics section in "
-        echo "this article: https://support.hypernode.com/knowledgebase/install-xdebug-hypernode-vagrant/"
+       # Restart PHP and Nginx
+       [ "$PHP_VERSION" == "php5" ] && service php5-fpm restart
+       [ "$PHP_VERSION" == "php5.5" ] && service php5.5-fpm restart
+       [ "$PHP_VERSION" == "php5.6" ] && service php5.6-fpm restart
+       [ "$PHP_VERSION" == "php7.0" ] && service php7.0-fpm restart
+       service nginx restart
     fi
+    echo ""
+    echo "Xdebug is installed. To configure Xdebug to send metrics to"
+    echo "your IDE, see the 'Configuring Xdebug to send metrics section in "
+    echo "this article: https://support.hypernode.com/knowledgebase/install-xdebug-hypernode-vagrant/"
 fi
 
 if ! $varnish_enabled; then 


### PR DESCRIPTION
https://github.com/ByteInternet/hypernode-vagrant/issues/160

```
vdloo@workstation4:~/code/projects/hypernode-vagrant$ vagrant up 
...
==> hypernode: Installing xdebug
...
==> hypernode: Selecting previously unselected package php-xdebug.
...
==> hypernode: Preparing to unpack .../php-xdebug_2.5.1-1_amd64.deb ...
==> hypernode: Unpacking php-xdebug (2.5.1-1) ...
==> hypernode: Setting up php-xdebug (2.5.1-1) ...
==> hypernode: Xdebug is installed. To configure Xdebug to send metrics to
==> hypernode: your IDE, see the 'Configuring Xdebug to send metrics section in 
==> hypernode: this article: https://support.hypernode.com/knowledgebase/install-xdebug-hypernode-vagrant/

vdloo@workstation4:~/code/projects/hypernode-vagrant$ vagrant ssh
vagrant@beb7b8-projects-magweb-vgr:~$ php -i | grep xdebug
/etc/php/7.0/cli/conf.d/20-xdebug.ini,
xdebug
xdebug support => enabled
```