### PR TITLE
upload to vagrant rsync is quiet

### DIFF
--- a/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/runner/upload.py
+++ b/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/runner/upload.py
@@ -16,7 +16,7 @@ def upload_project_to_vagrant(project_path, vagrant_info, ssh_user=HYPERNODE_VAG
     """
     log.info("Uploading project {} to /data/web/public on the vagrant.."
              "".format(project_path))
-    upload_project_command = "rsync -avz --delete " \
+    upload_project_command = "rsync -q -avz --delete " \
                              "-e 'ssh -p {Port} -i {IdentityFile} " \
                              "-oStrictHostKeyChecking=no " \
                              "-oUserKnownHostsFile=/dev/null' " \

--- a/tools/hypernode-vagrant-runner/tests/unit/hypernode_vagrant_runner/runner/upload/test_upload_project_to_vagrant.py
+++ b/tools/hypernode-vagrant-runner/tests/unit/hypernode_vagrant_runner/runner/upload/test_upload_project_to_vagrant.py
@@ -20,7 +20,7 @@ class TestUploadProjectToVagrant(TestCase):
             vagrant_info=self.vagrant_ssh_config
         )
 
-        expected_command = "rsync -avz --delete -e " \
+        expected_command = "rsync -q -avz --delete -e " \
                            "'ssh -p 2222 " \
                            "-i /tmp/tmpZrTKrM/.vagrant/machines/hypernode/virtualbox/private_key " \
                            "-oStrictHostKeyChecking=no " \
@@ -55,7 +55,7 @@ class TestUploadProjectToVagrant(TestCase):
             ssh_user='root'
         )
 
-        expected_command = "rsync -avz --delete -e " \
+        expected_command = "rsync -q -avz --delete -e " \
                            "'ssh -p 2222 " \
                            "-i /tmp/tmpZrTKrM/.vagrant/machines/hypernode/virtualbox/private_key " \
                            "-oStrictHostKeyChecking=no " \


### PR DESCRIPTION
silence output like this from the upload to the vagrant environment:
```
"/srv/jenkins/workspace/hypernode-kamikaze3-importer-integration/tasks/fixtures/clean/hypernode-vagrant/.vagrant/machines/hypernode/lxc/private_key"
Retrieved networking info from /srv/jenkins/workspace/hypernode-kamikaze3-importer-integration/tasks/fixtures/clean/hypernode-vagrant: {'Port': '22', 'IdentityFile': '"/srv/jenkins/workspace/hypernode-kamikaze3-importer-integration/tasks/fixtures/clean/hypernode-vagrant/.vagrant/machines/hypernode/lxc/private_key"', 'HostName': '10.0.3.187'}
Uploading project /srv/jenkins/workspace/hypernode-kamikaze3-importer-integration/tasks/fixtures/clean to /data/web/public on the vagrant..
Warning: Permanently added '10.0.3.187' (ECDSA) to the list of known hosts.
sending incremental file list
build.sh
hypernode-vagrant/
hypernode-vagrant/.gitignore
hypernode-vagrant/.local.base.yml
hypernode-vagrant/.travis.yml
hypernode-vagrant/README.md
hypernode-vagrant/Vagrantfile
hypernode-vagrant/composer.json
hypernode-vagrant/hypernode-kamikaze3_20170704.171140.dsc
hypernode-vagrant/hypernode-kamikaze3_20170704.171140.tar.gz
hypernode-vagrant/hypernode-kamikaze3_20170704.171140_amd64.build
hypernode-vagrant/hypernode-kamikaze3_20170704.171140_amd64.changes
hypernode-vagrant/local.yml
hypernode-vagrant/runtests.sh
hypernode-vagrant/.git/
hypernode-vagrant/.git/HEAD
hypernode-vagrant/.git/config
hypernode-vagrant/.git/description
hypernode-vagrant/.git/index
hypernode-vagrant/.git/packed-refs
```