### PR TITLE
Move port forwarding out of the virtualbox provider block

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,8 +76,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.provider :virtualbox do |vbox, override|
       override.vm.network "private_network", type: "dhcp"
-      override.vm.network "forwarded_port", guest: 80, host: 8080, auto_correct: true
-      override.vm.network "forwarded_port", guest: 3306, host: 3307, auto_correct: true
       vbox.memory = 2048
       vbox.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     end
@@ -87,6 +85,39 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       if File.exists?('/etc/redhat-release')
         lxc.customize 'network.link', 'virbr0'
       end
+    end
+
+    # Standardize Ports Naming Schema
+    if (settings.has_key?("ports"))
+      settings["ports"].each do |port|
+        port["guest"] ||= port["to"]
+        port["host"] ||= port["send"]
+        port["protocol"] ||= "tcp"
+      end
+    else
+      settings["ports"] = []
+    end
+
+    # Default Port Forwarding
+    default_ports = {
+      80 => 8080,
+      3306 => 3307,
+    }
+
+    # Use Default Port Forwarding Unless Overridden
+    unless settings.has_key?("default_ports") && settings["default_ports"] == false
+      default_ports.each do |guest, host|
+        unless settings["ports"].any? { |mapping| mapping["guest"] == guest }
+          config.vm.network "forwarded_port", guest: guest, host: host, host_ip: "0.0.0.0", auto_correct: true
+        end
+      end
+    end
+
+    # Add Custom Ports From Configuration
+    if settings.has_key?("ports")
+      settings["ports"].each do |port|
+        config.vm.network "forwarded_port", guest: port["guest"], host: port["host"], host_ip: "0.0.0.0", protocol: port["protocol"], auto_correct: true
+       end
     end
 
     if Vagrant.has_plugin?("vagrant-hostmanager")


### PR DESCRIPTION
This PR moves port forwarding out of the virtualbox provider block. Custom ports can be assigned through the project settings.

Example for custom port forwarding:
```
---
ports:
- send: 8082
  to: 80
- send: 33062
  to: 3306
fs:
  folders:
    magento2:
      host: data/web/magento2
      guest: "/data/web/magento2"
    nginx:
      host: data/web/nginx/
      guest: "/data/web/nginx/"
  type: nfs
  disabled_folders:
    magento1:
      host: data/web/public
      guest: "/data/web/public"
hostmanager:
  extra-aliases:
  - my-custom-store-url1.local
  - my-custom-store-url2.local
  default_domain: hypernode.local
magento:
  version: 2
php:
  version: 7.0
varnish:
  state: false
firewall:
  state: false
cgroup:
  state: false
xdebug:
  state: false
vagrant:
  box: hypernode_xenial
  box_url: http://vagrant.hypernode.com/customer/xenial/catalog.json
ubuntu_version: xenial
```