### PR TITLE
Allow memory to be set through settings

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,12 +76,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.provider :virtualbox do |vbox, override|
       override.vm.network "private_network", type: "dhcp"
-      vbox.memory = 2048
+      vbox.memory = settings["memory"] ||= 2048
       vbox.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     end
 
     config.vm.provider :lxc do |lxc, override|
-      lxc.customize 'cgroup.memory.limit_in_bytes', '2048M'
+      lxc.customize 'cgroup.memory.limit_in_bytes', "#{(settings['memory'] ||= 2048)}M"
       if File.exists?('/etc/redhat-release')
         lxc.customize 'network.link', 'virbr0'
       end


### PR DESCRIPTION
Sometimes we wish to increase the memory limit of a vagrant box. This PR allows the memory to be set in the configuration file.

Same as for my other PR, it would be nice to include this in the defaults dialog but due to the lack of free time I wont be able to implement such feature as of this moment.