### PR TITLE
Memory and port enhancements

### DIFF
--- a/.local.base.yml
+++ b/.local.base.yml
@@ -1,3 +1,5 @@
+ports: false
+memory: 2048
 fs:
   folders:
     magento2:

--- a/Documentation/archlinux_setup.md
+++ b/Documentation/archlinux_setup.md
@@ -14,8 +14,6 @@ If you encounter any issues relating to `vagrant-lxc` and not `hypernode-vagrant
 pacman -S rsync dnsmasq git lxc vagrant --needed --noconfirm
 ```
 
-You will also need to install [redir](https://linux.die.net/man/1/redir). Alternatively you could disable [port forwarding](https://www.vagrantup.com/docs/networking/forwarded_ports.html) by adding `default_ports: false` to your `local.yml`.
-
 ### Create the configuration file for the LXC's NAT bridge
 
 For more information about this and the following step see the host network configuration setting section of [this article about Linux Containers](https://wiki.archlinux.org/index.php/Linux_Containers) on the ArchWiki.

--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ Voila! Access your local Hypernode through [http://hypernode.local/](http://hype
 
 Virtualbox can be rather slow. In case you are on Linux you can also use LXC instead. 
 
-You must also install the [redir](http://manpages.ubuntu.com/manpages/xenial/man1/redir.1.html) package. Alternatively you could disable [port forwarding](https://www.vagrantup.com/docs/networking/forwarded_ports.html) by adding `default_ports: false` to your `local.yml`.
-
 To do this, change the synced folder type in local.yml to something other than virtualbox like rsync or nfs:
 ```
     fs:
@@ -266,6 +264,47 @@ Vagrant will notice the magento version changed and correct the shared folders s
     ==> hypernode: Disabling fs->folders->magento1 in the local.yml because Magento 2 was configured..
 ```
 
+
+## Change the allocated memory
+
+By default 2048M of memory is allocated to the hypernode, this value can be altered. To do so change the `memory` section in your `local.yml` to any valid value.
+
+```
+memory: 4096
+```
+
+For LXC it's enough to issue the `vagrant reload` command.
+
+For VirtualBox a rebuild of the machine is required. If `vagrant up` is issued for the first time the machine will be build with the specified `memory`. Otherwise a `vagrant destroy` should be issued first.
+If there is no possibility to issue `vagrant destroy` (due to local changes) the memory can be adjusted through the VirtualBox GUI. 
+
+
+## Port forwarding
+
+There is no port forwarding enabled by default, except for the default SSH forward managed by Vagrant. 
+Port forwarding can be set up by modifying the `ports: false` section in your `local.yml`.
+
+```
+ports:
+- send: 8080
+  to: 80
+- send: 33060
+  to: 3306
+- send: 2222
+  to: 22
+```
+
+Ports will be bound to 127.0.0.1 by default, which means the forward will only be accessible from the local machine.
+If remote access is wished a separate `bind-addr` can be added to those in question.
+
+ ```
+ ports:
+ - send: 8080
+   to: 80
+   bind-addr: 0.0.0.0
+ ```
+
+For LXC it's required to have the [redir](http://manpages.ubuntu.com/manpages/xenial/man1/redir.1.html) package installed.
 
 ## Troubleshooting
 

--- a/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/settings.py
+++ b/tools/hypernode-vagrant-runner/hypernode_vagrant_runner/settings.py
@@ -34,7 +34,7 @@ HYPERNODE_VAGRANT_DEFAULT_PHP_VERSION = '7.0'
 
 HYPERNODE_VAGRANT_CONFIGURATION = """
 ---
-default_ports: false
+ports: false
 fs:
   type: rsync
 hostmanager:


### PR DESCRIPTION
I made some changes to the port forwarding section. By default port forwarding is now disabled on a hypernode. Documentation is added on how to configure port forwarding and how to set up a custom memory value for the machine.

Forwarded ports are by default bound to 127.0.0.1:{PORT}

Quick example:
```
ports:
- send: 8082
  to: 80
```
```
paul@paul-MS-7A72:~/vagrant/hypernode/hypernode-vagrant$ netstat -na | grep 8082
tcp        0      0 127.0.0.1:8082          0.0.0.0:*               LISTEN
```

A custom bind-address can be set if (for instance) remote access is wanted:
```
ports:
- send: 8082
  to: 80
  bind-addr: 0.0.0.0
```
```
paul@paul-MS-7A72:~/vagrant/hypernode/hypernode-vagrant$ netstat -na | grep 8082
tcp        0      0 0.0.0.0:8082            0.0.0.0:*               LISTEN
```