### PR TITLE
Allow a static IP to be assigned to machine

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,12 +75,23 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
            -p #{settings['php']['version']}" \
 
     config.vm.provider :virtualbox do |vbox, override|
-      override.vm.network "private_network", type: "dhcp"
+      # Allow a static IP to be assigned if defined in the settings
+      if (settings.has_key?("ip") && settings["ip"] != "dhcp")
+        override.vm.network "private_network", ip: settings["ip"]
+      else
+        override.vm.network "private_network", type: "dhcp"
+      end
+
       vbox.memory = settings["memory"] ||= 2048
       vbox.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     end
 
     config.vm.provider :lxc do |lxc, override|
+      # Allow a static IP to be assigned if defined in the settings
+      if (settings.has_key?("ip") && settings["ip"] != "dhcp")
+        config.vm.network "private_network", ip: settings["ip"], lxc__bridge_name: 'vlxcbr1'
+      end
+
       lxc.customize 'cgroup.memory.limit_in_bytes', "#{(settings['memory'] ||= 2048)}M"
       if File.exists?('/etc/redhat-release')
         lxc.customize 'network.link', 'virbr0'


### PR DESCRIPTION
PR for #188 

Functionality works for me on Ubuntu 16.04 and doesn't break anything if the default config is kept.
Not sure how this will work on other distros when it comes to LXC. Virtualbox should work out of the box.