### PR TITLE
Fix issue where multiple host adapters where attached

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -89,7 +89,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provider :lxc do |lxc, override|
       # Allow a static IP to be assigned if defined in the settings
       if (settings.has_key?("ip") && settings["ip"] != "dhcp")
-        config.vm.network "private_network", ip: settings["ip"], lxc__bridge_name: 'vlxcbr1'
+        override.vm.network "private_network", ip: settings["ip"], lxc__bridge_name: 'vlxcbr1'
       end
 
       lxc.customize 'cgroup.memory.limit_in_bytes', "#{(settings['memory'] ||= 2048)}M"


### PR DESCRIPTION
When using a static ip with the virtualbox provider multiple host adapters would be attached to the machine.

Before:
```
==> hypernode: Preparing network interfaces based on configuration...
    hypernode: Adapter 1: nat
    hypernode: Adapter 2: hostonly
    hypernode: Adapter 3: hostonly
    hypernode: Adapter 4: hostonly
    hypernode: Adapter 5: hostonly
==> hypernode: Forwarding ports...
```

After:
```
==> hypernode: Preparing network interfaces based on configuration...
    hypernode: Adapter 1: nat
    hypernode: Adapter 2: hostonly
==> hypernode: Forwarding ports...
```