### PR TITLE
fix test site permissions

### DIFF
--- a/vagrant/provisioning/hypernode.sh
+++ b/vagrant/provisioning/hypernode.sh
@@ -73,6 +73,9 @@ fi
 if ! find /data/web/public/ -mindepth 1 -name '*.php' -name '*.html' | read; then
     cp /vagrant/vagrant/resources/*.{php,js,css} /data/web/public/
     chown -R $user:$user /data/web/public
+    if test -d /data/web/magento2; then
+       chown -R $user:$user /data/web/magento2
+    fi
 fi
 
 # Start the correct FPM daemon


### PR DESCRIPTION
currently if `magento_version` is `2`, the test site permissions will be
wrong because the chown doesn't resolve the symlink. this causes the
hypernode-importer not to overwrite the index.php file that is placed by
default because it would be owned by root:root.

before:
```
root@beb7b8-projects-magweb-vgr /data/web/public # ls -strlah
total 149K
 512 drwxrwxr-x 3 app  app     3 Sep  5  2016 ..
 512 -rw-rw-r-- 1 app  app    12 Nov 14  2016 .gitignore
 29K -rw-r--r-- 1 root root  25K Jun 22 15:35 style.css
4.5K -rw-r--r-- 1 root root  757 Jun 22 15:35 opensans.css
 53K -rw-r--r-- 1 root root  95K Jun 22 15:35 jquery.min.js
8.5K -rw-r--r-- 1 root root 8.0K Jun 22 15:35 index.php
 13K -rw-r--r-- 1 root root  29K Jun 22 15:35 bootstrap.min.js
 33K -rw-r--r-- 1 root root  98K Jun 22 15:35 bootstrap.min.css
8.5K drwxrwxr-x 2 app  app     9 Jun 22 15:35 .
```

after:
```
app@beb7b8-projects-magweb-vgr:~/public$ ls -stlrah
total 149K
 512 drwxrwxr-x 3 app app    3 Sep  5  2016 ..
 512 -rw-rw-r-- 1 app app   12 Nov 14  2016 .gitignore
4.5K -rw-r--r-- 1 app app  757 Jun 22 15:46 opensans.css
 53K -rw-r--r-- 1 app app  95K Jun 22 15:46 jquery.min.js
8.5K -rw-r--r-- 1 app app 8.0K Jun 22 15:46 index.php
 13K -rw-r--r-- 1 app app  29K Jun 22 15:46 bootstrap.min.js
 33K -rw-r--r-- 1 app app  98K Jun 22 15:46 bootstrap.min.css
8.5K drwxrwxr-x 2 app app    9 Jun 22 15:46 .
 29K -rw-r--r-- 1 app app  25K Jun 22 15:46 style.css
```