### PR TITLE
remove hypconfigmgmt install from Vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ You can start developing on your own local Hypernode within 15 minutes.
     vagrant up --provider virtualbox
 ```
 
+4. Install the (latest) [vagrant-hypconfigmgmt](https://rubygems.org/gems/vagrant-hypconfigmgmt/versions/) Vagrant plugin
+```
+vagrant plugin install vagrant-hypconfigmgmt
+```
+
+If you wish to run an earlier revision of `hypernode-vagrant` you can install an earlier matching `vagrant-hypconfigmgmt` by for example running `vagrant plugin install vagrant-hypconfigmgmt --plugin-version 0.0.10`. Automatically installing the correct bundled plugin no longer works since [Augustus 31 2018](https://stackoverflow.com/a/28801317).
+
 ### Configuring your hypernode vagrant
 
 The first time you run `vagrant up` after downloading the hypernode-vagrant zip file or cloning this git repository, some user input is required to prepare and setup some configuration:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can start developing on your own local Hypernode within 15 minutes.
 vagrant plugin install vagrant-hypconfigmgmt
 ```
 
-If you wish to run an earlier revision of `hypernode-vagrant` you can install an earlier matching `vagrant-hypconfigmgmt` by for example running `vagrant plugin install vagrant-hypconfigmgmt --plugin-version 0.0.10`. Automatically installing the correct bundled plugin no longer works since [Augustus 31 2018](https://stackoverflow.com/a/28801317).
+If you wish to run an earlier revision of `hypernode-vagrant` you can install an earlier matching `vagrant-hypconfigmgmt` by for example running `vagrant plugin install vagrant-hypconfigmgmt --plugin-version 0.0.10`.
 
 ### Configuring your hypernode vagrant
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,7 @@ settings = YAML.load_file(SETTINGS_FILE) rescue Hash.new(Hash.new(nil))
 require_relative 'vagrant/plugins/inline/ensure-varnish.rb'
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # run hypernode-vagrant configuration wizard if needed during 'vagrant up'
+  config.vagrant.plugins = {"vagrant-hypconfigmgmt" => {"version" => VAGRANT_HYPCONFIGMGMT_VERSION}}
   config.hypconfigmgmt.enabled = true  
 
   config.ssh.forward_agent = true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,12 +7,6 @@ require 'fileutils'
 VAGRANTFILE_API_VERSION = "2"
 VAGRANT_HYPCONFIGMGMT_VERSION = "0.0.11"
 
-# if vagrant-hypconfigmgmt is not installed, install it and abort
-if !Vagrant.has_plugin?("vagrant-hypconfigmgmt", version = VAGRANT_HYPCONFIGMGMT_VERSION) && !ARGV.include?("plugin") && !ARGV.include?("status")
-  system("vagrant plugin install vagrant-hypconfigmgmt --plugin-version #{VAGRANT_HYPCONFIGMGMT_VERSION}")
-  abort "Installed the vagrant-hypconfigmgmt plugin.\nFor the next configuration step, please again run: \"vagrant up\""
-end
-
 # path to local settings file
 SETTINGS_FILE = "local.yml"
 # load the settingsfile or if it does not exist yet a hash where every attribute two levels deep is nil


### PR DESCRIPTION
Automatically installing the correct bundled plugin no longer works since [Augustus 31 2018](https://stackoverflow.com/a/28801317)