### PR TITLE
add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 # Hypernode test environment for MacOSX and Linux
 
+NOTICE: This project has been deprecated in favor of [hypernode-docker](https://github.com/ByteInternet/hypernode-docker). It is possible to keep using this Vagrant Virtualbox and LXC box, but we will push no further box updates. Since we have released the [official Hypernode Docker image for Magento development](https://community.hypernode.io/hypernode-docker/) we have seen that most users prefer that over Vagrant for the advantages in performance and compatibility, and we encourage all `hypernode-vagrant` users to switch to that. If you wish to continue using the `hypernode-vagrant` boxfiles that is possible, but note that no new box files will be uploaded. However, it is possible to still receive newer versions of Hypernode related tooling by manually running `apt-get update` and `apt-get upgrade`. Note that official support from Byte on this box is no longer available though.
+
 You can start developing on your own local Hypernode within 15 minutes.
 
 ## Starting the test environment


### PR DESCRIPTION
Due to declining usage of Vagrant (in favor of Docker related development environments), breaking changes in [newer versions of LXC](https://linuxcontainers.org/lxc/news/) and general usability we have decided to stop support for `hypernode-vagrant` and will no longer be publishing new boxfiles of recent Hypernode revisions. We recommend all users that wish to use an image that is as up to date as possible with their production Hypernode environments but do not want to pull updates manually from our `apt` repos to switch to [hypernode-docker](https://github.com/ByteInternet/hypernode-docker). Note that as of right now we will not be removing the existing Vagrant images, but we will stop creating new boxfiles and official support.